### PR TITLE
fix the bug for Final table write happens before running final_agg_dq and final_query_dq expectations

### DIFF
--- a/spark_expectations/core/expectations.py
+++ b/spark_expectations/core/expectations.py
@@ -333,9 +333,7 @@ class SparkExpectations:
                             expectations=expectations,
                             table_name=table_name,
                             _input_count=_input_count,
-                            write_to_table=write_to_table,
                             spark_conf=spark_conf,
-                            options=options,
                             options_error_table=options_error_table,
                         )
 
@@ -525,6 +523,17 @@ class SparkExpectations:
                             _log.info(
                                 "ended processing data quality rules for query level expectations on final dataframe"
                             )
+
+                        if row_dq and write_to_table:
+                            _log.info("Writing into the final table started")
+                            self._writer.write_df_to_table(
+                                _row_dq_df,
+                                f"{table_name}",
+                                spark_conf=spark_conf,
+                                options=options,
+                            )
+                            _log.info("Writing into the final table ended")
+
                     else:
                         raise SparkExpectationsDataframeNotReturnedException(
                             "error occurred while processing spark "

--- a/spark_expectations/utils/regulate_flow.py
+++ b/spark_expectations/utils/regulate_flow.py
@@ -30,9 +30,7 @@ class SparkExpectationsRegulateFlow:
         expectations: Dict[str, List[dict]],
         table_name: str,
         _input_count: int = 0,
-        write_to_table: bool = False,
         spark_conf: Optional[Dict[str, Any]] = None,
-        options: Optional[Dict[str, str]] = None,
         options_error_table: Optional[Dict[str, str]] = None,
     ) -> Any:
         """
@@ -169,16 +167,6 @@ class SparkExpectationsRegulateFlow:
                     _final_query_dq_flag=final_query_dq_flag,
                 )
                 _context.print_dataframe_with_debugger(df)
-
-                if row_dq_flag and write_to_table:
-                    _log.info("Writing into the final table started")
-                    _writer.write_df_to_table(
-                        df,
-                        f"{table_name}",
-                        spark_conf=spark_conf,
-                        options=options,
-                    )
-                    _log.info("Writing into the final table ended")
 
                 return df, agg_dq_res, _error_count, "Passed"
 

--- a/spark_expectations/utils/regulate_flow.py
+++ b/spark_expectations/utils/regulate_flow.py
@@ -41,9 +41,7 @@ class SparkExpectationsRegulateFlow:
             expectations: expectations dictionary which contains rules
             table_name: name of the table
             _input_count: number of records in the source dataframe
-            write_to_table: Mark it as "True" if the dataframe need to be written as table
             spark_conf: spark configurations(which is optional)
-            options: spark configurations to write data into the final table(which is optional)
             options_error_table: spark configurations to write data into the error table(which is optional)
 
         Returns:

--- a/tests/core/test_expectations.py
+++ b/tests/core/test_expectations.py
@@ -17,7 +17,6 @@ from spark_expectations.core.exceptions import (
 )
 from spark_expectations.notifications.push.spark_expectations_notify import SparkExpectationsNotify
 from spark_expectations.sinks.utils.collect_statistics import SparkExpectationsCollectStatistics
-from pyspark.sql.utils import AnalysisException
 
 spark = get_spark_session()
 

--- a/tests/core/test_expectations.py
+++ b/tests/core/test_expectations.py
@@ -17,6 +17,7 @@ from spark_expectations.core.exceptions import (
 )
 from spark_expectations.notifications.push.spark_expectations_notify import SparkExpectationsNotify
 from spark_expectations.sinks.utils.collect_statistics import SparkExpectationsCollectStatistics
+from pyspark.sql.utils import AnalysisException
 
 spark = get_spark_session()
 
@@ -2249,6 +2250,13 @@ def test_with_expectations(input_df,
     if isinstance(expected_output, type) and issubclass(expected_output, Exception):
         with pytest.raises(expected_output, match=r"error occurred while processing spark expectations .*"):
             get_dataset()  # decorated_func()
+
+        if status.get("final_agg_dq_status") == 'Failed' or status.get("final_query_dq_status") == 'Failed':
+            try:
+                spark.table("dq_spark.test_final_table")
+                assert False
+            except Exception as e:
+                assert True
 
     else:
         get_dataset()  # decorated_func()

--- a/tests/utils/test_regulate_flow.py
+++ b/tests/utils/test_regulate_flow.py
@@ -1591,9 +1591,7 @@ def test_execute_dq_process(_mock_notify,
         expectations,
         "dq_spark.test_final_table",
         input_count,
-        write_to_table,
         spark_conf,
-        options,
         options_error_table
     )
 
@@ -1648,8 +1646,8 @@ def test_execute_dq_process(_mock_notify,
             assert _status == status.get("row_dq_status")
             assert _agg_dq_res == agg_or_query_dq_res
             assert output_count == expected_df.count()
-            if write_to_table is True:
-                assert output_count == spark.table("dq_spark.test_final_table").count()
+            # if write_to_table is True:
+            #     assert output_count == spark.table("dq_spark.test_final_table").count()
 
         elif (rule_type == "agg_dq"):
             # assert dq result for source_agg & final_agg
@@ -1817,9 +1815,7 @@ def test_execute_dq_process_exception(df,
             expectations,
             "dq_spark.test_final_table",
             input_count,
-            write_to_table,
             spark_conf,
-            options,
             options_error_table
         )
 


### PR DESCRIPTION
This PR addresses the issue - #11 

## Description
when `write_to_table` option is set, the write should only happen when all dq checks are completed. Right now the table is being saved after running row_dq rules but agg_final or query_final may fail . So moving the `write` part to `expectations.py`

## Related Issue
#11 

## Motivation and Context
If the `agg_final` and `query_final` dq rule fails, there is no point in saving the dataframe as table. 

## How Has This Been Tested?
Ran locally and unit tested 

## Screenshots (if appropriate):
<img width="1104" alt="Screenshot 2023-09-03 at 7 14 56 AM" src="https://github.com/Nike-Inc/spark-expectations/assets/11095154/6ae6d90e-4d77-4b55-9e22-3c618bd03b61">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
