### PR TITLE
[Feature] updating code to work for retries if the save table fails

### DIFF
--- a/spark_expectations/core/exceptions.py
+++ b/spark_expectations/core/exceptions.py
@@ -41,9 +41,17 @@ class SparkExpectationsMiscException(Exception):
     pass
 
 
+class SparkExpectationsWriteToTableException(Exception):
+    """
+    Throw this exception when spark expectations encounters exceptions while writing to table
+    """
+
+    pass
+
+
 class SparkExpectationsSlackNotificationException(Exception):
     """
-    Throw this exception when spark expectations encounters miscellaneous exceptions
+    Throw this exception when spark expectations encounters exceptions while sending Slack notifications
     """
 
     pass
@@ -51,7 +59,7 @@ class SparkExpectationsSlackNotificationException(Exception):
 
 class SparkExpectationsTeamsNotificationException(Exception):
     """
-    Throw this exception when spark expectations encounters miscellaneous exceptions
+    Throw this exception when spark expectations encounters exceptions while sending Teams notifications
     """
 
     pass
@@ -59,7 +67,7 @@ class SparkExpectationsTeamsNotificationException(Exception):
 
 class SparkExpectationsEmailException(Exception):
     """
-    Throw this exception when spark expectations encounters miscellaneous exceptions
+    Throw this exception when spark expectations encounters exceptions while sending email notifications
     """
 
     pass

--- a/spark_expectations/core/exceptions.py
+++ b/spark_expectations/core/exceptions.py
@@ -41,14 +41,6 @@ class SparkExpectationsMiscException(Exception):
     pass
 
 
-class SparkExpectationsWriteToTableException(Exception):
-    """
-    Throw this exception when spark expectations encounters exceptions while writing to table
-    """
-
-    pass
-
-
 class SparkExpectationsSlackNotificationException(Exception):
     """
     Throw this exception when spark expectations encounters exceptions while sending Slack notifications

--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -17,7 +17,8 @@ from pyspark.sql.functions import (
 from spark_expectations import _log
 from spark_expectations.core.exceptions import (
     SparkExpectationsUserInputOrConfigInvalidException,
-    SparkExpectationsMiscException, SparkExpectationsWriteToTableException,
+    SparkExpectationsMiscException,
+    SparkExpectationsWriteToTableException,
 )
 from spark_expectations.secrets import SparkExpectationsSecretsBackend
 from spark_expectations.utils.udf import remove_empty_maps
@@ -37,6 +38,7 @@ class SparkExpectationsWriter:
     def __post_init__(self) -> None:
         self.spark = self._context.spark
 
+    # pylint: disable=too-many-nested-blocks
     def save_df_as_table(
         self, df: DataFrame, table_name: str, config: dict, stats_table: bool = False
     ) -> None:
@@ -83,10 +85,12 @@ class SparkExpectationsWriter:
                 )
             if config["options"] is not None and config["options"] != {}:
                 _df_writer = _df_writer.options(**config["options"])
-            
+
             max_retries = 10
             for attempt in range(1, max_retries + 2):
-                _log.info("Writing records to table: %s, attempt: %s", table_name, attempt)
+                _log.info(
+                    "Writing records to table: %s, attempt: %s", table_name, attempt
+                )
                 try:
                     if config["format"] == "bigquery":
                         _df_writer.option("table", table_name).save()
@@ -102,14 +106,18 @@ class SparkExpectationsWriter:
                             }
 
                             # Set product_id in table properties
-                            if table_properties_dict.get("product_id") is None or table_properties_dict.get(
-                                "product_id"
-                            ) != self._context.product_id:
+                            if (
+                                table_properties_dict.get("product_id") is None
+                                or table_properties_dict.get("product_id")
+                                != self._context.product_id
+                            ):
                                 _log.info(
-                                    f"product_id is not set for table {table_name} in tableproperties, setting it now"
+                                    "product_id is not set for table %s in tableproperties, setting it now",
+                                    table_name,
                                 )
                                 self.spark.sql(
-                                    f"ALTER TABLE {table_name} SET TBLPROPERTIES ('product_id' = '{self._context.product_id}')"
+                                    f"ALTER TABLE {table_name} SET TBLPROPERTIES ('product_id' = "
+                                    f"'{self._context.product_id}')"
                                 )
                     _log.info("finished writing records to table: %s,", table_name)
                     break
@@ -119,16 +127,23 @@ class SparkExpectationsWriter:
                         raise SparkExpectationsWriteToTableException(
                             f"Write failed in 10 retries for the table - {table_name}, with error: {e}"
                         )
-                    else:
-                        # If there are more retry attempts left, log the error and continue with the next attempt
-                        _log.info(f"Retrying writing to table {table_name} as it failed with error. Attempt {attempt} of {max_retries}. sleeping for 30 seconds")
-                        time.sleep(30)
+
+                    _log.info(
+                        "Retrying writing to table %s as it failed with error. Attempt %s of %s. "
+                        "sleeping for 30 seconds",
+                        table_name,
+                        attempt,
+                        max_retries,
+                    )
+                    time.sleep(30)
         except SparkExpectationsWriteToTableException:
             raise
         except Exception as e:
             raise SparkExpectationsUserInputOrConfigInvalidException(
                 f"error occurred while writing data in to the table - {table_name}: {e}"
             )
+
+    # pylint: enable=too-many-nested-blocks
 
     def write_error_stats(self) -> None:
         """

--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -1,3 +1,4 @@
+import time
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple, List
 from datetime import datetime
@@ -16,7 +17,7 @@ from pyspark.sql.functions import (
 from spark_expectations import _log
 from spark_expectations.core.exceptions import (
     SparkExpectationsUserInputOrConfigInvalidException,
-    SparkExpectationsMiscException,
+    SparkExpectationsMiscException, SparkExpectationsWriteToTableException,
 )
 from spark_expectations.secrets import SparkExpectationsSecretsBackend
 from spark_expectations.utils.udf import remove_empty_maps
@@ -82,16 +83,48 @@ class SparkExpectationsWriter:
                 )
             if config["options"] is not None and config["options"] != {}:
                 _df_writer = _df_writer.options(**config["options"])
+            
+            max_retries = 10
+            for attempt in range(1, max_retries + 2):
+                _log.info("Writing records to table: %s, attempt: %s", table_name, attempt)
+                try:
+                    if config["format"] == "bigquery":
+                        _df_writer.option("table", table_name).save()
+                    else:
+                        _df_writer.saveAsTable(name=table_name)
+                        if not stats_table:
+                            # Fetch table properties
+                            table_properties = self.spark.sql(
+                                f"SHOW TBLPROPERTIES {table_name}"
+                            ).collect()
+                            table_properties_dict = {
+                                row["key"]: row["value"] for row in table_properties
+                            }
 
-            if config["format"] == "bigquery":
-                _df_writer.option("table", table_name).save()
-            else:
-                _df_writer.saveAsTable(name=table_name)
-                self.spark.sql(
-                    f"ALTER TABLE {table_name} SET TBLPROPERTIES ('product_id' = '{self._context.product_id}')"
-                )
-            _log.info("finished writing records to table: %s,", table_name)
-
+                            # Set product_id in table properties
+                            if table_properties_dict.get("product_id") is None or table_properties_dict.get(
+                                "product_id"
+                            ) != self._context.product_id:
+                                _log.info(
+                                    f"product_id is not set for table {table_name} in tableproperties, setting it now"
+                                )
+                                self.spark.sql(
+                                    f"ALTER TABLE {table_name} SET TBLPROPERTIES ('product_id' = '{self._context.product_id}')"
+                                )
+                    _log.info("finished writing records to table: %s,", table_name)
+                    break
+                except Exception as e:
+                    if attempt == max_retries + 1:
+                        # If this was the last retry attempt, re-raise the exception
+                        raise SparkExpectationsWriteToTableException(
+                            f"Write failed in 10 retries for the table - {table_name}, with error: {e}"
+                        )
+                    else:
+                        # If there are more retry attempts left, log the error and continue with the next attempt
+                        _log.info(f"Retrying writing to table {table_name} as it failed with error. Attempt {attempt} of {max_retries}. sleeping for 30 seconds")
+                        time.sleep(30)
+        except SparkExpectationsWriteToTableException:
+            raise
         except Exception as e:
             raise SparkExpectationsUserInputOrConfigInvalidException(
                 f"error occurred while writing data in to the table - {table_name}: {e}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Making code changes so as to support retries for writing into table if it fails. Update table properties only if the property is not already written.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#60 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When there are multiple processes writing at the same time into the stats table, having issues with concurrent writes. Adding retries and also write table properties only when not written.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The code has been unit tested

## Screenshots (if appropriate):
<img width="1415" alt="image" src="https://github.com/Nike-Inc/spark-expectations/assets/25289866/eaf96108-9259-474a-8faa-aebb7af8cf39">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
