### PR TITLE
rewrote generate_summarised_row_dq_res

### DIFF
--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -12,6 +12,7 @@ from pyspark.sql.functions import (
     create_map,
     explode,
     to_json,
+    col,
 )
 from spark_expectations import _log
 from spark_expectations.core.exceptions import (
@@ -440,31 +441,23 @@ class SparkExpectationsWriter:
 
         """
         try:
+            df_exploded = df.select(explode(f"meta_{rule_type}_results").alias("row_dq_res"))
 
-            def update_dict(accumulator: dict) -> dict:  # pragma: no cover
-                if accumulator.get("failed_row_count") is None:  # pragma: no cover
-                    accumulator["failed_row_count"] = str(2)  # pragma: no cover
-                else:  # pragma: no cover
-                    accumulator["failed_row_count"] = str(  # pragma: no cover
-                        int(accumulator["failed_row_count"]) + 1  # pragma: no cover
-                    )  # pragma: no cover
+            keys = (df_exploded
+                    .select(explode("row_dq_res"))
+                    .select("key")
+                    .distinct()
+                    .rdd.flatMap(lambda x: x)
+                    .collect())
+            nested_keys = [col("row_dq_res").getItem(k).alias(k) for k in keys]
 
-                return accumulator  # pragma: no cover
+            df_select = df_exploded.select(*nested_keys)
+            df_pivot = df_select.groupBy(df_select.columns).count().withColumnRenamed('count', 'failed_row_count')
 
-            summarised_row_dq_dict: Dict[str, Dict[str, str]] = (
-                df.select(explode(f"meta_{rule_type}_results").alias("row_dq_res"))
-                .rdd.map(
-                    lambda rule_meta_dict: (
-                        rule_meta_dict[0]["rule"],
-                        {**rule_meta_dict[0], "failed_row_count": 1},
-                    )
-                )
-                .reduceByKey(lambda acc, itr: update_dict(acc))
-            ).collectAsMap()
+            keys += ['failed_row_count']
+            summarised_row_dq_list = df_pivot.rdd.map(lambda x: {i: x[i] for i in keys}).collect()
 
-            self._context.set_summarised_row_dq_res(
-                list(summarised_row_dq_dict.values())
-            )
+            self._context.set_summarised_row_dq_res(summarised_row_dq_list)
 
         except Exception as e:
             raise SparkExpectationsMiscException(

--- a/tests/sinks/utils/test_writer.py
+++ b/tests/sinks/utils/test_writer.py
@@ -635,8 +635,8 @@ def test_write_error_records_final_dependent(save_df_as_table,
                 {"meta_row_dq_results": [{"rule": "rule2"}]},
             ],
             [
-                {"rule": "rule1", "failed_row_count": "2"},
-                {"rule": "rule2", "failed_row_count": "2"},
+                {"rule": "rule1", "failed_row_count": 2},
+                {"rule": "rule2", "failed_row_count": 2},
             ]
     ),
     (
@@ -645,7 +645,7 @@ def test_write_error_records_final_dependent(save_df_as_table,
                 {"meta_row_dq_results": [{"rule": "rule1"}]},
             ],
             [
-                {"rule": "rule1", "failed_row_count": "2"},
+                {"rule": "rule1", "failed_row_count": 2},
             ]
     )
 ])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR solves this issue: https://github.com/Nike-Inc/spark-expectations/issues/62

## Motivation and Context
See issue. 

## How Has This Been Tested?
The tests that were already in place still succeed. Next to that, I tested data quality checks that I already had in place on my data. This resulted in error_counts that were the same as the sum of the failed_row_counts in the row_dq_res_summary. This was not the case for me for the same scenario's with the current implementation of spark-expectations. Therefore, the bug is solved by using this implementation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
