### PR TITLE
improving failed recording writing process and enabling details stats table

### DIFF
--- a/spark_expectations/config/user_config.py
+++ b/spark_expectations/config/user_config.py
@@ -40,6 +40,8 @@ class Constants:
     )
 
     se_enable_streaming = "se.enable.streaming"
+    se_stats_relational_format = "spark.expectations.stats.relational.format"
+    se_error_data_load_into_error_table = "se.enable.error.table"
 
     secret_type = "se.streaming.secret.type"
 
@@ -58,3 +60,4 @@ class Constants:
     dbx_secret_app_name = "se.streaming.dbx.secret.app.name"
     dbx_secret_token = "se.streaming.dbx.secret.token"
     dbx_topic_name = "se.streaming.dbx.topic.name"
+

--- a/spark_expectations/config/user_config.py
+++ b/spark_expectations/config/user_config.py
@@ -41,7 +41,7 @@ class Constants:
 
     se_enable_streaming = "se.enable.streaming"
     se_stats_relational_format = "spark.expectations.stats.relational.format"
-    se_error_data_load_into_error_table = "se.enable.error.table"
+    se_error_data_load_into_error_table = "spark.expectations.enable.error.table"
 
     secret_type = "se.streaming.secret.type"
 

--- a/spark_expectations/core/expectations.py
+++ b/spark_expectations/core/expectations.py
@@ -243,7 +243,6 @@ class SparkExpectations:
 
             if _se_stats_relational_format:
                 self._context.set_se_stats_relational_format(_se_stats_relational_format)
-                self._context.set_dag_metadata(_dag_metadata)
 
             @self._notification.send_notification_decorator
             @self._statistics_decorator.collect_stats_decorator

--- a/spark_expectations/examples/sample_dq_bigquery.py
+++ b/spark_expectations/examples/sample_dq_bigquery.py
@@ -56,6 +56,8 @@ user_conf = {
     user_config.se_notifications_on_fail: True,
     user_config.se_notifications_on_error_drop_exceeds_threshold_breach: True,
     user_config.se_notifications_on_error_drop_threshold: 15,
+    user_config.se_stats_relational_format: True,
+    user_config.se_error_data_load_into_error_table: True,
 }
 
 

--- a/spark_expectations/examples/sample_dq_delta.py
+++ b/spark_expectations/examples/sample_dq_delta.py
@@ -40,6 +40,8 @@ user_conf = {
     user_config.se_notifications_on_fail: True,
     user_config.se_notifications_on_error_drop_exceeds_threshold_breach: True,
     user_config.se_notifications_on_error_drop_threshold: 15,
+    user_config.se_stats_relational_format: True,
+    user_config.se_error_data_load_into_error_table: True,
 }
 
 

--- a/spark_expectations/examples/sample_dq_iceberg.py
+++ b/spark_expectations/examples/sample_dq_iceberg.py
@@ -39,6 +39,8 @@ user_conf = {
     user_config.se_notifications_on_fail: True,
     user_config.se_notifications_on_error_drop_exceeds_threshold_breach: True,
     user_config.se_notifications_on_error_drop_threshold: 15,
+    user_config.se_stats_relational_format: True,
+    user_config.se_error_data_load_into_error_table: True,
 }
 
 

--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -132,7 +132,8 @@ class SparkExpectationsWriter:
         output_count: int = self._context.get_output_count
         DQ_Run_ID = self._context.get_run_id
         product_id = self._context.product_id
-        dq_date = self._context.get_run_date
+        dq_date = self._context.get_row_dq_start_time.replace(tzinfo=timezone.utc).strftime(
+            "%Y-%m-%d") if self._context.get_row_dq_start_time else '1900-01-01'
         start_time = self._context.get_row_dq_start_time.replace(tzinfo=timezone.utc).strftime(
             "%Y-%m-%d %H:%M:%S") if self._context.get_row_dq_start_time else '1900-01-01'
         end_time = self._context.get_row_dq_end_time.replace(tzinfo=timezone.utc).strftime(

--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -532,7 +532,7 @@ class SparkExpectationsWriter:
                     self._context.get_run_id_name, lit(self._context.get_run_id)
                 )
                 .withColumn(
-                    self._context.get_run_date_name,
+                    self._context.get_run_date_time_name,
                     lit(self._context.get_run_date),
                 )
             )

--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -227,11 +227,11 @@ class SparkExpectationsWriter:
 
         df_rel_format_final.show(truncate=False)
 
-        dq_stats_rel = f"{self._context.get_dq_stats_table_name}_rel"
+        dq_stats_detail = f"{self._context.get_dq_stats_table_name}_detail"
 
         self.save_df_as_table(
             df_rel_format_final,
-            dq_stats_rel,
+            dq_stats_detail,
             config=self._context.get_stats_table_writer_config,
             stats_table=True,
         )

--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -494,10 +494,11 @@ class SparkExpectationsWriter:
         try:
             _log.info("_write_error_records_final started")
             df = df.withColumn("sequence_number", monotonically_increasing_id())
+            df.cache()
             df_seq = df
             df = df.select("sequence_number",
                            *[dq_column for dq_column in df.columns if dq_column.startswith(f"{rule_type}")])
-            df.cache()
+            
             failed_records = [
                 f"size({dq_column}) != 0"
                 for dq_column in df.columns

--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -474,8 +474,13 @@ class SparkExpectationsWriter:
                     }
                 )
             else:
-                _log.info(
-                    "Streaming stats to kafka is disabled, hence skipping writing to kafka"
+                _log.info("Streaming stats to kafka is disabled, hence skipping writing to kafka" )
+
+            if self._context.get_action_if_failed_for_fail:
+                raise SparkExpectOrFailException(
+                    f"Job failed, as there is a data quality issue at one of the rule "
+                    f"expectations and the action_if_failed "
+                    "suggested to fail"
                 )
 
         except Exception as e:

--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -421,7 +421,7 @@ class SparkExpectationsWriter:
 
             _log.info(
                 "Writing metrics to the stats table: %s, ended",
-                {self._context.get_dq_stats_table_name},
+                self._context.get_dq_stats_table_name,
             )
 
             # TODO check if streaming_stats is set to off, if it's enabled only then this should run

--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -219,11 +219,10 @@ class SparkExpectationsWriter:
         df_rel_format_final = df_rel_format_all.union(df_rel_format_agg).union(df_rel_format_query)
 
         df_rel_format_final = df_rel_format_final \
-            .withColumn("dq_dag_metadata_info", lit(self._context.get_dag_metadata)) \
             .select("DQ_Run_ID", "product_id", "table_name", "rule_type", "rule", "expectation", "status",
                     "error_count",
                     "actual_result", "row_input_count", "dq_run_date", "dq_rule_run_start_date_time",
-                    "dq_rule_run_end_date_time", "dq_dag_metadata_info")
+                    "dq_rule_run_end_date_time")
 
         df_rel_format_final.show(truncate=False)
 

--- a/spark_expectations/utils/actions.py
+++ b/spark_expectations/utils/actions.py
@@ -227,7 +227,8 @@ class SparkExpectationsActions:
                         )
                         .alias(column)
                     )
-                    if _context.get_se_stats_relational_format:
+                    
+                    if _context.get_se_stats_relational_format and rule_type in ['agg_dq', 'query_dq']:
                         agg_dq_results.append(SparkExpectationsActions.agg_dq_result_relational(_context, rule, df))
 
             if _context.get_se_stats_relational_format:
@@ -332,6 +333,8 @@ class SparkExpectationsActions:
             ):
                 _df_dq = _df_dq.filter(~array_contains(_df_dq.action_if_failed, "drop"))
             else:
+                #added below line to raise expection after executing dq rules
+                _context._set_action_if_failed_fail = True
                 if _row_dq_flag:
                     _context.set_row_dq_status("Failed")
                 elif _source_agg_dq_flag:
@@ -343,11 +346,11 @@ class SparkExpectationsActions:
                 elif _final_query_dq_flag:
                     _context.set_final_query_dq_status("Failed")
 
-                raise SparkExpectOrFailException(
-                    f"Job failed, as there is a data quality issue at {_rule_type} "
-                    f"expectations and the action_if_failed "
-                    "suggested to fail"
-                )
+                # raise SparkExpectOrFailException(
+                #     f"Job failed, as there is a data quality issue at {_rule_type} "
+                #     f"expectations and the action_if_failed "
+                #     "suggested to fail"
+                # )
 
             if 'sequence_number' in [column for column in _df_dq.columns]:
                 _df_dq = _df_dq_main.join(_df_dq, _df_dq.sequence_number == _df_dq_main.sequence_number, "left").select(

--- a/spark_expectations/utils/reader.py
+++ b/spark_expectations/utils/reader.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Union, Dict
+from typing import Optional, Union, Dict, Tuple
 from dataclasses import dataclass
 
 from pyspark.sql import DataFrame
@@ -41,6 +41,8 @@ class SparkExpectationsReader:
                 user_config.se_notifications_slack_webhook_url: "",
                 user_config.se_notifications_enable_teams: False,
                 user_config.se_notifications_teams_webhook_url: "",
+				user_config.se_stats_relational_format: False,
+    			user_config.se_error_data_load_into_error_table: False,
             }
 
             _notification_dict: Dict[str, Union[str, int, bool]] = (
@@ -140,7 +142,7 @@ class SparkExpectationsReader:
         target_table: str,
         is_dlt: bool = False,
         tag: Optional[str] = None,
-    ) -> tuple[dict, dict]:
+    ) -> Tuple[Dict, Dict]:
         """
         This function fetches the data quality rules from the table and return it as a dictionary
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR solves two issues: https://github.com/Nike-Inc/spark-expectations/issues/68 and https://github.com/Nike-Inc/spark-expectations/issues/50

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
see issues

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

performance has been tested on 44 million records. performance has improved write_error_records_final function and  action_on_rules function. Additionally, introduced new feature, that has details stats in relational format

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
