### PR TITLE
support if dataframe of instance pyspark.sql.connect.dataframe.Dataframe is passed as input

### DIFF
--- a/docs/delta.md
+++ b/docs/delta.md
@@ -11,7 +11,7 @@ builder = (
         SparkSession.builder.config(
             "spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension"
         )
-        .config("spark.jars.packages", "io.delta:delta-core_2.12:2.4.0")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.0.0")
         .config(
             "spark.sql.catalog.spark_catalog",
             "org.apache.spark.sql.delta.catalog.DeltaCatalog",

--- a/poetry.lock
+++ b/poetry.lock
@@ -49,30 +49,25 @@ astroid = ["astroid (>=1,<2)", "astroid (>=2,<4)"]
 test = ["astroid (>=1,<2)", "astroid (>=2,<4)", "pytest"]
 
 [[package]]
-name = "astunparse"
-version = "1.6.3"
-description = "An AST unparser for Python"
+name = "beautifulsoup4"
+version = "4.12.3"
+description = "Screen-scraping library"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6.0"
 files = [
-    {file = "astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8"},
-    {file = "astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872"},
+    {file = "beautifulsoup4-4.12.3-py3-none-any.whl", hash = "sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed"},
+    {file = "beautifulsoup4-4.12.3.tar.gz", hash = "sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"},
 ]
 
 [package.dependencies]
-six = ">=1.6.1,<2.0"
-wheel = ">=0.23.0,<1.0"
+soupsieve = ">1.2"
 
-[[package]]
-name = "backcall"
-version = "0.2.0"
-description = "Specifications for callback functions passed in to an API"
-optional = false
-python-versions = "*"
-files = [
-    {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
-    {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
-]
+[package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
 
 [[package]]
 name = "black"
@@ -178,74 +173,89 @@ requests = "*"
 
 [[package]]
 name = "certifi"
-version = "2024.2.2"
+version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.2.2-py3-none-any.whl", hash = "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"},
-    {file = "certifi-2024.2.2.tar.gz", hash = "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"},
+    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
+    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
 ]
 
 [[package]]
 name = "cffi"
-version = "1.16.0"
+version = "1.17.1"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088"},
-    {file = "cffi-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9"},
-    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673"},
-    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896"},
-    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684"},
-    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7"},
-    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614"},
-    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743"},
-    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d"},
-    {file = "cffi-1.16.0-cp310-cp310-win32.whl", hash = "sha256:9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a"},
-    {file = "cffi-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1"},
-    {file = "cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404"},
-    {file = "cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417"},
-    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627"},
-    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8a9d3ebe49f084ad71f9269834ceccbf398253c9fac910c4fd7053ff1386936"},
-    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d"},
-    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5bf44d66cdf9e893637896c7faa22298baebcd18d1ddb6d2626a6e39793a1d56"},
-    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e"},
-    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c6a164aa47843fb1b01e941d385aab7215563bb8816d80ff3a363a9f8448a8dc"},
-    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb"},
-    {file = "cffi-1.16.0-cp311-cp311-win32.whl", hash = "sha256:2c56b361916f390cd758a57f2e16233eb4f64bcbeee88a4881ea90fca14dc6ab"},
-    {file = "cffi-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba"},
-    {file = "cffi-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956"},
-    {file = "cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:68e7c44931cc171c54ccb702482e9fc723192e88d25a0e133edd7aff8fcd1f6e"},
-    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd808f9c129ba2beda4cfc53bde801e5bcf9d6e0f22f095e45327c038bfe68e"},
-    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2"},
-    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcc8eb6d5902bb1cf6dc4f187ee3ea80a1eba0a89aba40a5cb20a5087d961357"},
-    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6"},
-    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e715596e683d2ce000574bae5d07bd522c781a822866c20495e52520564f0969"},
-    {file = "cffi-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520"},
-    {file = "cffi-1.16.0-cp312-cp312-win32.whl", hash = "sha256:b2ca4e77f9f47c55c194982e10f058db063937845bb2b7a86c84a6cfe0aefa8b"},
-    {file = "cffi-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235"},
-    {file = "cffi-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc"},
-    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a09582f178759ee8128d9270cd1344154fd473bb77d94ce0aeb2a93ebf0feaf0"},
-    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e760191dd42581e023a68b758769e2da259b5d52e3103c6060ddc02c9edb8d7b"},
-    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80876338e19c951fdfed6198e70bc88f1c9758b94578d5a7c4c91a87af3cf31c"},
-    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a6a14b17d7e17fa0d207ac08642c8820f84f25ce17a442fd15e27ea18d67c59b"},
-    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6602bc8dc6f3a9e02b6c22c4fc1e47aa50f8f8e6d3f78a5e16ac33ef5fefa324"},
-    {file = "cffi-1.16.0-cp38-cp38-win32.whl", hash = "sha256:131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a"},
-    {file = "cffi-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:31d13b0f99e0836b7ff893d37af07366ebc90b678b6664c955b54561fc36ef36"},
-    {file = "cffi-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed"},
-    {file = "cffi-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2"},
-    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872"},
-    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8"},
-    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f"},
-    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4"},
-    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098"},
-    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000"},
-    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe"},
-    {file = "cffi-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed86a35631f7bfbb28e108dd96773b9d5a6ce4811cf6ea468bb6a359b256b1e4"},
-    {file = "cffi-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8"},
-    {file = "cffi-1.16.0.tar.gz", hash = "sha256:bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0"},
+    {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
+    {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be"},
+    {file = "cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c"},
+    {file = "cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"},
+    {file = "cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655"},
+    {file = "cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8"},
+    {file = "cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65"},
+    {file = "cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9"},
+    {file = "cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d"},
+    {file = "cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a"},
+    {file = "cffi-1.17.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:636062ea65bd0195bc012fea9321aca499c0504409f413dc88af450b57ffd03b"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7eac2ef9b63c79431bc4b25f1cd649d7f061a28808cbc6c47b534bd789ef964"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e221cf152cff04059d011ee126477f0d9588303eb57e88923578ace7baad17f9"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:31000ec67d4221a71bd3f67df918b1f88f676f1c3b535a7eb473255fdc0b83fc"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f17be4345073b0a7b8ea599688f692ac3ef23ce28e5df79c04de519dbc4912c"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2b1fac190ae3ebfe37b979cc1ce69c81f4e4fe5746bb401dca63a9062cdaf1"},
+    {file = "cffi-1.17.1-cp38-cp38-win32.whl", hash = "sha256:7596d6620d3fa590f677e9ee430df2958d2d6d6de2feeae5b20e82c00b76fbf8"},
+    {file = "cffi-1.17.1-cp38-cp38-win_amd64.whl", hash = "sha256:78122be759c3f8a014ce010908ae03364d00a1f81ab5c7f4a7a5120607ea56e1"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d599671f396c4723d016dbddb72fe8e0397082b0a77a4fab8028923bec050e8"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98e3969bcff97cae1b2def8ba499ea3d6f31ddfdb7635374834cf89a1a08ecf0"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f1e22e8c4419538cb197e4dd60acc919d7696e5ef98ee4da4e01d3f8cfa4cc5a"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e"},
+    {file = "cffi-1.17.1-cp39-cp39-win32.whl", hash = "sha256:e31ae45bc2e29f6b2abd0de1cc3b9d5205aa847cafaecb8af1476a609a2f6eb7"},
+    {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
+    {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
 ]
 
 [package.dependencies]
@@ -479,33 +489,33 @@ files = [
 
 [[package]]
 name = "debugpy"
-version = "1.8.1"
+version = "1.8.5"
 description = "An implementation of the Debug Adapter Protocol for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "debugpy-1.8.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:3bda0f1e943d386cc7a0e71bfa59f4137909e2ed947fb3946c506e113000f741"},
-    {file = "debugpy-1.8.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dda73bf69ea479c8577a0448f8c707691152e6c4de7f0c4dec5a4bc11dee516e"},
-    {file = "debugpy-1.8.1-cp310-cp310-win32.whl", hash = "sha256:3a79c6f62adef994b2dbe9fc2cc9cc3864a23575b6e387339ab739873bea53d0"},
-    {file = "debugpy-1.8.1-cp310-cp310-win_amd64.whl", hash = "sha256:7eb7bd2b56ea3bedb009616d9e2f64aab8fc7000d481faec3cd26c98a964bcdd"},
-    {file = "debugpy-1.8.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:016a9fcfc2c6b57f939673c874310d8581d51a0fe0858e7fac4e240c5eb743cb"},
-    {file = "debugpy-1.8.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd97ed11a4c7f6d042d320ce03d83b20c3fb40da892f994bc041bbc415d7a099"},
-    {file = "debugpy-1.8.1-cp311-cp311-win32.whl", hash = "sha256:0de56aba8249c28a300bdb0672a9b94785074eb82eb672db66c8144fff673146"},
-    {file = "debugpy-1.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:1a9fe0829c2b854757b4fd0a338d93bc17249a3bf69ecf765c61d4c522bb92a8"},
-    {file = "debugpy-1.8.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3ebb70ba1a6524d19fa7bb122f44b74170c447d5746a503e36adc244a20ac539"},
-    {file = "debugpy-1.8.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2e658a9630f27534e63922ebf655a6ab60c370f4d2fc5c02a5b19baf4410ace"},
-    {file = "debugpy-1.8.1-cp312-cp312-win32.whl", hash = "sha256:caad2846e21188797a1f17fc09c31b84c7c3c23baf2516fed5b40b378515bbf0"},
-    {file = "debugpy-1.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:edcc9f58ec0fd121a25bc950d4578df47428d72e1a0d66c07403b04eb93bcf98"},
-    {file = "debugpy-1.8.1-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:7a3afa222f6fd3d9dfecd52729bc2e12c93e22a7491405a0ecbf9e1d32d45b39"},
-    {file = "debugpy-1.8.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d915a18f0597ef685e88bb35e5d7ab968964b7befefe1aaea1eb5b2640b586c7"},
-    {file = "debugpy-1.8.1-cp38-cp38-win32.whl", hash = "sha256:92116039b5500633cc8d44ecc187abe2dfa9b90f7a82bbf81d079fcdd506bae9"},
-    {file = "debugpy-1.8.1-cp38-cp38-win_amd64.whl", hash = "sha256:e38beb7992b5afd9d5244e96ad5fa9135e94993b0c551ceebf3fe1a5d9beb234"},
-    {file = "debugpy-1.8.1-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:bfb20cb57486c8e4793d41996652e5a6a885b4d9175dd369045dad59eaacea42"},
-    {file = "debugpy-1.8.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efd3fdd3f67a7e576dd869c184c5dd71d9aaa36ded271939da352880c012e703"},
-    {file = "debugpy-1.8.1-cp39-cp39-win32.whl", hash = "sha256:58911e8521ca0c785ac7a0539f1e77e0ce2df753f786188f382229278b4cdf23"},
-    {file = "debugpy-1.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:6df9aa9599eb05ca179fb0b810282255202a66835c6efb1d112d21ecb830ddd3"},
-    {file = "debugpy-1.8.1-py2.py3-none-any.whl", hash = "sha256:28acbe2241222b87e255260c76741e1fbf04fdc3b6d094fcf57b6c6f75ce1242"},
-    {file = "debugpy-1.8.1.zip", hash = "sha256:f696d6be15be87aef621917585f9bb94b1dc9e8aced570db1b8a6fc14e8f9b42"},
+    {file = "debugpy-1.8.5-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:7e4d594367d6407a120b76bdaa03886e9eb652c05ba7f87e37418426ad2079f7"},
+    {file = "debugpy-1.8.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4413b7a3ede757dc33a273a17d685ea2b0c09dbd312cc03f5534a0fd4d40750a"},
+    {file = "debugpy-1.8.5-cp310-cp310-win32.whl", hash = "sha256:dd3811bd63632bb25eda6bd73bea8e0521794cda02be41fa3160eb26fc29e7ed"},
+    {file = "debugpy-1.8.5-cp310-cp310-win_amd64.whl", hash = "sha256:b78c1250441ce893cb5035dd6f5fc12db968cc07f91cc06996b2087f7cefdd8e"},
+    {file = "debugpy-1.8.5-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:606bccba19f7188b6ea9579c8a4f5a5364ecd0bf5a0659c8a5d0e10dcee3032a"},
+    {file = "debugpy-1.8.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db9fb642938a7a609a6c865c32ecd0d795d56c1aaa7a7a5722d77855d5e77f2b"},
+    {file = "debugpy-1.8.5-cp311-cp311-win32.whl", hash = "sha256:4fbb3b39ae1aa3e5ad578f37a48a7a303dad9a3d018d369bc9ec629c1cfa7408"},
+    {file = "debugpy-1.8.5-cp311-cp311-win_amd64.whl", hash = "sha256:345d6a0206e81eb68b1493ce2fbffd57c3088e2ce4b46592077a943d2b968ca3"},
+    {file = "debugpy-1.8.5-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:5b5c770977c8ec6c40c60d6f58cacc7f7fe5a45960363d6974ddb9b62dbee156"},
+    {file = "debugpy-1.8.5-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0a65b00b7cdd2ee0c2cf4c7335fef31e15f1b7056c7fdbce9e90193e1a8c8cb"},
+    {file = "debugpy-1.8.5-cp312-cp312-win32.whl", hash = "sha256:c9f7c15ea1da18d2fcc2709e9f3d6de98b69a5b0fff1807fb80bc55f906691f7"},
+    {file = "debugpy-1.8.5-cp312-cp312-win_amd64.whl", hash = "sha256:28ced650c974aaf179231668a293ecd5c63c0a671ae6d56b8795ecc5d2f48d3c"},
+    {file = "debugpy-1.8.5-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:3df6692351172a42af7558daa5019651f898fc67450bf091335aa8a18fbf6f3a"},
+    {file = "debugpy-1.8.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cd04a73eb2769eb0bfe43f5bfde1215c5923d6924b9b90f94d15f207a402226"},
+    {file = "debugpy-1.8.5-cp38-cp38-win32.whl", hash = "sha256:8f913ee8e9fcf9d38a751f56e6de12a297ae7832749d35de26d960f14280750a"},
+    {file = "debugpy-1.8.5-cp38-cp38-win_amd64.whl", hash = "sha256:a697beca97dad3780b89a7fb525d5e79f33821a8bc0c06faf1f1289e549743cf"},
+    {file = "debugpy-1.8.5-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:0a1029a2869d01cb777216af8c53cda0476875ef02a2b6ff8b2f2c9a4b04176c"},
+    {file = "debugpy-1.8.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e84c276489e141ed0b93b0af648eef891546143d6a48f610945416453a8ad406"},
+    {file = "debugpy-1.8.5-cp39-cp39-win32.whl", hash = "sha256:ad84b7cde7fd96cf6eea34ff6c4a1b7887e0fe2ea46e099e53234856f9d99a34"},
+    {file = "debugpy-1.8.5-cp39-cp39-win_amd64.whl", hash = "sha256:7b0fe36ed9d26cb6836b0a51453653f8f2e347ba7348f2bbfe76bfeb670bfb1c"},
+    {file = "debugpy-1.8.5-py2.py3-none-any.whl", hash = "sha256:55919dce65b471eff25901acf82d328bbd5b833526b6c1364bd5133754777a44"},
+    {file = "debugpy-1.8.5.zip", hash = "sha256:b2112cfeb34b4507399d298fe7023a16656fc553ed5246536060ca7bd0e668d0"},
 ]
 
 [[package]]
@@ -558,13 +568,13 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.2.1"
+version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.2.1-py3-none-any.whl", hash = "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad"},
-    {file = "exceptiongroup-1.2.1.tar.gz", hash = "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"},
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
 ]
 
 [package.extras]
@@ -572,13 +582,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "executing"
-version = "2.0.1"
+version = "2.1.0"
 description = "Get the currently executing AST node of a frame, and other information"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.8"
 files = [
-    {file = "executing-2.0.1-py2.py3-none-any.whl", hash = "sha256:eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc"},
-    {file = "executing-2.0.1.tar.gz", hash = "sha256:35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147"},
+    {file = "executing-2.1.0-py2.py3-none-any.whl", hash = "sha256:8d63781349375b5ebccc3142f4b30350c0cd9c79f921cde38be2be4637e98eaf"},
+    {file = "executing-2.1.0.tar.gz", hash = "sha256:8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab"},
 ]
 
 [package.extras]
@@ -586,19 +596,19 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "filelock"
-version = "3.14.0"
+version = "3.16.0"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.14.0-py3-none-any.whl", hash = "sha256:43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f"},
-    {file = "filelock-3.14.0.tar.gz", hash = "sha256:6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a"},
+    {file = "filelock-3.16.0-py3-none-any.whl", hash = "sha256:f6ed4c963184f4c84dd5557ce8fece759a3724b37b80c6c4f20a2f63a4dc6609"},
+    {file = "filelock-3.16.0.tar.gz", hash = "sha256:81de9eb8453c769b63369f87f11131a7ab04e367f8d97ad39dc230daa07e3bec"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
-typing = ["typing-extensions (>=4.8)"]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.1.1)", "pytest (>=8.3.2)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.3)"]
+typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "flake8"
@@ -680,29 +690,103 @@ doc = ["sphinx (==4.3.2)", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphi
 test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
 
 [[package]]
+name = "google"
+version = "3.0.0"
+description = "Python bindings to the Google search engine."
+optional = false
+python-versions = "*"
+files = [
+    {file = "google-3.0.0-py2.py3-none-any.whl", hash = "sha256:889cf695f84e4ae2c55fbc0cfdaf4c1e729417fa52ab1db0485202ba173e4935"},
+    {file = "google-3.0.0.tar.gz", hash = "sha256:143530122ee5130509ad5e989f0512f7cb218b2d4eddbafbad40fd10e8d8ccbe"},
+]
+
+[package.dependencies]
+beautifulsoup4 = "*"
+
+[[package]]
 name = "griffe"
-version = "0.45.2"
+version = "1.3.1"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "griffe-0.45.2-py3-none-any.whl", hash = "sha256:297ec8530d0c68e5b98ff86fb588ebc3aa3559bb5dc21f3caea8d9542a350133"},
-    {file = "griffe-0.45.2.tar.gz", hash = "sha256:83ce7dcaafd8cb7f43cbf1a455155015a1eb624b1ffd93249e5e1c4a22b2fdb2"},
+    {file = "griffe-1.3.1-py3-none-any.whl", hash = "sha256:940aeb630bc3054b4369567f150b6365be6f11eef46b0ed8623aea96e6d17b19"},
+    {file = "griffe-1.3.1.tar.gz", hash = "sha256:3f86a716b631a4c0f96a43cb75d05d3c85975003c20540426c0eba3b0581c56a"},
 ]
 
 [package.dependencies]
-astunparse = {version = ">=1.6", markers = "python_version < \"3.9\""}
 colorama = ">=0.4"
 
 [[package]]
+name = "grpcio"
+version = "1.48.1"
+description = "HTTP/2-based RPC framework"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "grpcio-1.48.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:19f9c021ae858d3ef6d5ec4c0acf3f0b0a61e599e5aa36c36943c209520a0e66"},
+    {file = "grpcio-1.48.1-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:b0fa666fecdb1b118d37823937e9237afa17fe734fc4dbe6dd642e1e4cca0246"},
+    {file = "grpcio-1.48.1-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:a661d4b9b314327dec1e92ed57e591e8e5eb055700e0ba9e9687f734d922dcb6"},
+    {file = "grpcio-1.48.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:598c8c42420443c55431eba1821c7a2f72707f1ff674a4de9e0bb03282923cfb"},
+    {file = "grpcio-1.48.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c924d4e0493fd536ba3b82584b370e8b3c809ef341f9f828cff2dc3c761b3ab"},
+    {file = "grpcio-1.48.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a5edbcb8289681fcb5ded7542f2b7dd456489e83007a95e32fcaf55e9f18603e"},
+    {file = "grpcio-1.48.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9d116106cf220c79e91595523c893f1cf09ec0c2ea49de4fb82152528b7e6833"},
+    {file = "grpcio-1.48.1-cp310-cp310-win32.whl", hash = "sha256:5d81cd3c161291339ed3b469250c2f5013c3083dea7796e93aedff8f05fdcec1"},
+    {file = "grpcio-1.48.1-cp310-cp310-win_amd64.whl", hash = "sha256:d751f8beb383c4a5a95625d7ccc1ab183b98b02c6a88924814ea7fbff530872d"},
+    {file = "grpcio-1.48.1-cp36-cp36m-linux_armv7l.whl", hash = "sha256:1471e6f25a8e47d9f88499f48c565fc5b2876e8ee91bfb0ff33eaadd188b7ea6"},
+    {file = "grpcio-1.48.1-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:9fba1d0ba7cf56811728f1951c800a9aca6677e86433c5e353f2cc2c4039fda6"},
+    {file = "grpcio-1.48.1-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:f3a99ed422c38bd1bc893cb2cb2cea6d64173ec30927f699e95f5f58bdf625cf"},
+    {file = "grpcio-1.48.1-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b005502c59835f9ba3c3f8742f64c19eeb3db41eae1a89b035a559b39b421803"},
+    {file = "grpcio-1.48.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0ef1dafb4eadeaca58aec8c721a5a73d551064b0c63d57fa003e233277c642e"},
+    {file = "grpcio-1.48.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:9477967e605ba08715dcc769b5ee0f0d8b22bda40ef25a0df5a8759e5a4d21a5"},
+    {file = "grpcio-1.48.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:dbba883c2b6d63949bc98ab1950bc22cf7c8d4e8cb68de6edde49d3cccd8fd26"},
+    {file = "grpcio-1.48.1-cp36-cp36m-win32.whl", hash = "sha256:8bbaa6647986b874891bc682a1093df54cbdb073b5d4b844a2b480c47c7ffafd"},
+    {file = "grpcio-1.48.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e02f6ba10a3d4e289fa7ae91b301783a750d118b60f17924ca05e506c7d29bc8"},
+    {file = "grpcio-1.48.1-cp37-cp37m-linux_armv7l.whl", hash = "sha256:97dc35a99c61d5f35ec6457d3df0a4695ba9bb04a35686e1c254462b15c53f98"},
+    {file = "grpcio-1.48.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:ca382028cdfd2d79b7704b2acb8ae1fb54e9e1a03a6765e1895ba89a6fcfaba1"},
+    {file = "grpcio-1.48.1-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:3d319a0c89ffac9b8dfc75bfe727a4c835d18bbccc14203b20eb5949c6c7d87d"},
+    {file = "grpcio-1.48.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1b81849061c67c2ffaa6ed27aa3d9b0762e71e68e784e24b0330b7b1c67470a"},
+    {file = "grpcio-1.48.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ff1be0474846ed15682843b187e6062f845ddfeaceb2b28972073f474f7b735"},
+    {file = "grpcio-1.48.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:53b6306f9473020bc47ddf64ca704356466e63d5f88f5c2a7bf0a4692e7f03c4"},
+    {file = "grpcio-1.48.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dad2501603f954f222a6e555413c454a5f8d763ab910fbab3855bcdfef6b3148"},
+    {file = "grpcio-1.48.1-cp37-cp37m-win32.whl", hash = "sha256:4786323555a9f2c6380cd9a9922bcfd42165a51d68d242eebfcdfdc667651c96"},
+    {file = "grpcio-1.48.1-cp37-cp37m-win_amd64.whl", hash = "sha256:934aad7350d9577f4275e787f3d91d3c8ff4efffa8d6b807d343d3c891ff53eb"},
+    {file = "grpcio-1.48.1-cp38-cp38-linux_armv7l.whl", hash = "sha256:2563357697f5f2d7fd80c1b07a57ef4736551327ad84de604e7b9f6c1b6b4e20"},
+    {file = "grpcio-1.48.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:1d065f40fe74b52b88a6c42d4373a0983f1b0090f952a0747f34f2c11d6cbc64"},
+    {file = "grpcio-1.48.1-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:3340cb2224cc397954def015729391d85fb31135b5a7efca363e73e6f1b0e908"},
+    {file = "grpcio-1.48.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d03009a26f7edca9f0a581aa5d3153242b815b858cb4790e34a955afb303c6ba"},
+    {file = "grpcio-1.48.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53fa2fc1a1713195fa7acf7443a6f59b6ac7837607690f813c66cc18a9cb8135"},
+    {file = "grpcio-1.48.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a6a750c8324f3974e95265d3f9a0541573c537af1f67b3f6f46bf9c0b2e1b36"},
+    {file = "grpcio-1.48.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:626822d799d8fab08f07c8d95ef5c36213d24143f7cad3f548e97413db9f4110"},
+    {file = "grpcio-1.48.1-cp38-cp38-win32.whl", hash = "sha256:ca5209ef89f7607be47a308fa92308cf079805ed556ecda672f00039a26e366f"},
+    {file = "grpcio-1.48.1-cp38-cp38-win_amd64.whl", hash = "sha256:7cee20a4f873d61274d70c28ff63d19677d9eeea869c6a9cbaf3a00712336b6c"},
+    {file = "grpcio-1.48.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:460f5bec23fffa3c041aeba1f93a0f06b7a29e6a4da3658a52e1a866494920ab"},
+    {file = "grpcio-1.48.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:c54734a6eb3be544d332e65c846236d02e5fc71325e8c53af91e83a46b87b506"},
+    {file = "grpcio-1.48.1-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:c6b6969c529521c86884a13745a4b68930db1ef2e051735c0f479d0a7adb25b6"},
+    {file = "grpcio-1.48.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:346bef672a1536d59437210f16af35389d715d2b321bfe4899b3d6476a196706"},
+    {file = "grpcio-1.48.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f29627d66ae816837fd32c9450dc9c54780962cd74d034513ed829ba3ab46652"},
+    {file = "grpcio-1.48.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:b01faf7934c606d5050cf055c1d03943180f23d995d68d04cf50c80d1ef2c65a"},
+    {file = "grpcio-1.48.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:741eeff39a26d26da2b6d74ff0559f882ee95ee4e3b20c0b4b829021cb917f96"},
+    {file = "grpcio-1.48.1-cp39-cp39-win32.whl", hash = "sha256:a15409bc1d05c52ecb00f5e42ab8ff280e7149f2eb854728f628fb2a0a161a5b"},
+    {file = "grpcio-1.48.1-cp39-cp39-win_amd64.whl", hash = "sha256:2b6c336409937fd1cd2bf78eb72651f44d292d88da5e63059a4e8bd01b9d7411"},
+    {file = "grpcio-1.48.1.tar.gz", hash = "sha256:660217eccd2943bf23ea9a36e2a292024305aec04bf747fbcff1f5032b83610e"},
+]
+
+[package.dependencies]
+six = ">=1.5.2"
+
+[package.extras]
+protobuf = ["grpcio-tools (>=1.48.1)"]
+
+[[package]]
 name = "identify"
-version = "2.5.36"
+version = "2.6.1"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "identify-2.5.36-py2.py3-none-any.whl", hash = "sha256:37d93f380f4de590500d9dba7db359d0d3da95ffe7f9de1753faa159e71e7dfa"},
-    {file = "identify-2.5.36.tar.gz", hash = "sha256:e5e00f54165f9047fbebeb4a560f9acfb8af4c88232be60a488e9b68d122745d"},
+    {file = "identify-2.6.1-py2.py3-none-any.whl", hash = "sha256:53863bcac7caf8d2ed85bd20312ea5dcfc22226800f6d6881f232d861db5a8f0"},
+    {file = "identify-2.6.1.tar.gz", hash = "sha256:91478c5fb7c3aac5ff7bf9b4344f803843dc586832d5f110d672b19aa1984c98"},
 ]
 
 [package.extras]
@@ -710,33 +794,40 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 files = [
-    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
-    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
 ]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "importlib-metadata"
-version = "7.1.0"
+version = "8.5.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570"},
-    {file = "importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"},
+    {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
+    {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
 ]
 
 [package.dependencies]
-zipp = ">=0.5"
+zipp = ">=3.20"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
+test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
+type = ["pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -751,13 +842,13 @@ files = [
 
 [[package]]
 name = "ipykernel"
-version = "6.29.4"
+version = "6.29.5"
 description = "IPython Kernel for Jupyter"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ipykernel-6.29.4-py3-none-any.whl", hash = "sha256:1181e653d95c6808039c509ef8e67c4126b3b3af7781496c7cbfb5ed938a27da"},
-    {file = "ipykernel-6.29.4.tar.gz", hash = "sha256:3d44070060f9475ac2092b760123fadf105d2e2493c24848b6691a7c4f42af5c"},
+    {file = "ipykernel-6.29.5-py3-none-any.whl", hash = "sha256:afdb66ba5aa354b09b91379bac28ae4afebbb30e8b39510c9690afb7a10421b5"},
+    {file = "ipykernel-6.29.5.tar.gz", hash = "sha256:f093a22c4a40f8828f8e330a9c297cb93dcab13bd9678ded6de8e5cf81c56215"},
 ]
 
 [package.dependencies]
@@ -784,42 +875,40 @@ test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0)", "pytest-asyncio 
 
 [[package]]
 name = "ipython"
-version = "8.12.3"
+version = "8.18.1"
 description = "IPython: Productive Interactive Computing"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "ipython-8.12.3-py3-none-any.whl", hash = "sha256:b0340d46a933d27c657b211a329d0be23793c36595acf9e6ef4164bc01a1804c"},
-    {file = "ipython-8.12.3.tar.gz", hash = "sha256:3910c4b54543c2ad73d06579aa771041b7d5707b033bd488669b4cf544e3b363"},
+    {file = "ipython-8.18.1-py3-none-any.whl", hash = "sha256:e8267419d72d81955ec1177f8a29aaa90ac80ad647499201119e2f05e99aa397"},
+    {file = "ipython-8.18.1.tar.gz", hash = "sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27"},
 ]
 
 [package.dependencies]
-appnope = {version = "*", markers = "sys_platform == \"darwin\""}
-backcall = "*"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 decorator = "*"
+exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 jedi = ">=0.16"
 matplotlib-inline = "*"
 pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
-pickleshare = "*"
-prompt-toolkit = ">=3.0.30,<3.0.37 || >3.0.37,<3.1.0"
+prompt-toolkit = ">=3.0.41,<3.1.0"
 pygments = ">=2.4.0"
 stack-data = "*"
 traitlets = ">=5"
 typing-extensions = {version = "*", markers = "python_version < \"3.10\""}
 
 [package.extras]
-all = ["black", "curio", "docrepr", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.21)", "pandas", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
+all = ["black", "curio", "docrepr", "exceptiongroup", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.22)", "pandas", "pickleshare", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio (<0.22)", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
 black = ["black"]
-doc = ["docrepr", "ipykernel", "matplotlib", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "typing-extensions"]
+doc = ["docrepr", "exceptiongroup", "ipykernel", "matplotlib", "pickleshare", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio (<0.22)", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "typing-extensions"]
 kernel = ["ipykernel"]
 nbconvert = ["nbconvert"]
 nbformat = ["nbformat"]
 notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
-test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
-test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.21)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
+test = ["pickleshare", "pytest (<7.1)", "pytest-asyncio (<0.22)", "testpath"]
+test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.22)", "pandas", "pickleshare", "pytest (<7.1)", "pytest-asyncio (<0.22)", "testpath", "trio"]
 
 [[package]]
 name = "isort"
@@ -884,13 +973,13 @@ files = [
 
 [[package]]
 name = "jupyter-client"
-version = "8.6.2"
+version = "8.6.3"
 description = "Jupyter protocol implementation and client libraries"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_client-8.6.2-py3-none-any.whl", hash = "sha256:50cbc5c66fd1b8f65ecb66bc490ab73217993632809b6e505687de18e9dea39f"},
-    {file = "jupyter_client-8.6.2.tar.gz", hash = "sha256:2bda14d55ee5ba58552a8c53ae43d215ad9868853489213f37da060ced54d8df"},
+    {file = "jupyter_client-8.6.3-py3-none-any.whl", hash = "sha256:e8a19cc986cc45905ac3362915f410f3af85424b4c0905e94fa5f2cb08e8f23f"},
+    {file = "jupyter_client-8.6.3.tar.gz", hash = "sha256:35b3a0947c4a6e9d589eb97d7d4cd5e90f910ee73101611f01283732bd6d9419"},
 ]
 
 [package.dependencies]
@@ -1196,6 +1285,7 @@ optional = false
 python-versions = ">=2.7.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 files = [
     {file = "mkdocs-markdownextradata-plugin-0.2.5.tar.gz", hash = "sha256:9c562e8fe375647d5692d11dfe369a7bdd50302174d35995fce2aeca58036ec6"},
+    {file = "mkdocs_markdownextradata_plugin-0.2.5-py3-none-any.whl", hash = "sha256:5ad40822b1755646bf17c95fd4a719f53d25634470978dc6a5529365caf73227"},
 ]
 
 [package.dependencies]
@@ -1346,25 +1436,118 @@ files = [
 
 [[package]]
 name = "nodeenv"
-version = "1.9.0"
+version = "1.9.1"
 description = "Node.js virtual environment builder"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
-    {file = "nodeenv-1.9.0-py2.py3-none-any.whl", hash = "sha256:508ecec98f9f3330b636d4448c0f1a56fc68017c68f1e7857ebc52acf0eb879a"},
-    {file = "nodeenv-1.9.0.tar.gz", hash = "sha256:07f144e90dae547bf0d4ee8da0ee42664a42a04e02ed68e06324348dafe4bdb1"},
+    {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
+    {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
+]
+
+[[package]]
+name = "numpy"
+version = "1.26.4"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
+    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
+    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
+    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
+    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
+    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
+    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
+    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
+    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
+    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
+    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
 ]
 
 [[package]]
 name = "packaging"
-version = "24.0"
+version = "24.1"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
-    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
+    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
+    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
+
+[[package]]
+name = "pandas"
+version = "1.5.3"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pandas-1.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3749077d86e3a2f0ed51367f30bf5b82e131cc0f14260c4d3e499186fccc4406"},
+    {file = "pandas-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:972d8a45395f2a2d26733eb8d0f629b2f90bebe8e8eddbb8829b180c09639572"},
+    {file = "pandas-1.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:50869a35cbb0f2e0cd5ec04b191e7b12ed688874bd05dd777c19b28cbea90996"},
+    {file = "pandas-1.5.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3ac844a0fe00bfaeb2c9b51ab1424e5c8744f89860b138434a363b1f620f354"},
+    {file = "pandas-1.5.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a0a56cef15fd1586726dace5616db75ebcfec9179a3a55e78f72c5639fa2a23"},
+    {file = "pandas-1.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:478ff646ca42b20376e4ed3fa2e8d7341e8a63105586efe54fa2508ee087f328"},
+    {file = "pandas-1.5.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6973549c01ca91ec96199e940495219c887ea815b2083722821f1d7abfa2b4dc"},
+    {file = "pandas-1.5.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c39a8da13cede5adcd3be1182883aea1c925476f4e84b2807a46e2775306305d"},
+    {file = "pandas-1.5.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f76d097d12c82a535fda9dfe5e8dd4127952b45fea9b0276cb30cca5ea313fbc"},
+    {file = "pandas-1.5.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e474390e60ed609cec869b0da796ad94f420bb057d86784191eefc62b65819ae"},
+    {file = "pandas-1.5.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f2b952406a1588ad4cad5b3f55f520e82e902388a6d5a4a91baa8d38d23c7f6"},
+    {file = "pandas-1.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:bc4c368f42b551bf72fac35c5128963a171b40dce866fb066540eeaf46faa003"},
+    {file = "pandas-1.5.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14e45300521902689a81f3f41386dc86f19b8ba8dd5ac5a3c7010ef8d2932813"},
+    {file = "pandas-1.5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9842b6f4b8479e41968eced654487258ed81df7d1c9b7b870ceea24ed9459b31"},
+    {file = "pandas-1.5.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:26d9c71772c7afb9d5046e6e9cf42d83dd147b5cf5bcb9d97252077118543792"},
+    {file = "pandas-1.5.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fbcb19d6fceb9e946b3e23258757c7b225ba450990d9ed63ccceeb8cae609f7"},
+    {file = "pandas-1.5.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:565fa34a5434d38e9d250af3c12ff931abaf88050551d9fbcdfafca50d62babf"},
+    {file = "pandas-1.5.3-cp38-cp38-win32.whl", hash = "sha256:87bd9c03da1ac870a6d2c8902a0e1fd4267ca00f13bc494c9e5a9020920e1d51"},
+    {file = "pandas-1.5.3-cp38-cp38-win_amd64.whl", hash = "sha256:41179ce559943d83a9b4bbacb736b04c928b095b5f25dd2b7389eda08f46f373"},
+    {file = "pandas-1.5.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c74a62747864ed568f5a82a49a23a8d7fe171d0c69038b38cedf0976831296fa"},
+    {file = "pandas-1.5.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c4c00e0b0597c8e4f59e8d461f797e5d70b4d025880516a8261b2817c47759ee"},
+    {file = "pandas-1.5.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a50d9a4336a9621cab7b8eb3fb11adb82de58f9b91d84c2cd526576b881a0c5a"},
+    {file = "pandas-1.5.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd05f7783b3274aa206a1af06f0ceed3f9b412cf665b7247eacd83be41cf7bf0"},
+    {file = "pandas-1.5.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f69c4029613de47816b1bb30ff5ac778686688751a5e9c99ad8c7031f6508e5"},
+    {file = "pandas-1.5.3-cp39-cp39-win32.whl", hash = "sha256:7cec0bee9f294e5de5bbfc14d0573f65526071029d036b753ee6507d2a21480a"},
+    {file = "pandas-1.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:dfd681c5dc216037e0b0a2c821f5ed99ba9f03ebcf119c7dac0e9a7b960b9ec9"},
+    {file = "pandas-1.5.3.tar.gz", hash = "sha256:74a3fd7e5a7ec052f183273dc7b0acd3a863edf7520f5d3a1765c04ffdb3b0b1"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
+    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
+]
+python-dateutil = ">=2.8.1"
+pytz = ">=2020.1"
+
+[package.extras]
+test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
 name = "parso"
@@ -1421,31 +1604,20 @@ files = [
 ptyprocess = ">=0.5"
 
 [[package]]
-name = "pickleshare"
-version = "0.7.5"
-description = "Tiny 'shelve'-like database with concurrency support"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"},
-    {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
-]
-
-[[package]]
 name = "platformdirs"
-version = "4.2.2"
+version = "4.3.3"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.2.2-py3-none-any.whl", hash = "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee"},
-    {file = "platformdirs-4.2.2.tar.gz", hash = "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"},
+    {file = "platformdirs-4.3.3-py3-none-any.whl", hash = "sha256:50a5450e2e84f44539718293cbb1da0a0885c9d14adf21b77bae4e66fc99d9b5"},
+    {file = "platformdirs-4.3.3.tar.gz", hash = "sha256:d4e0b7d8ec176b341fb03cb11ca12d0276faa8c485f9cd218f613840463fc2c0"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
-type = ["mypy (>=1.8)"]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.11.2)"]
 
 [[package]]
 name = "pluggy"
@@ -1482,13 +1654,13 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.45"
+version = "3.0.47"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "prompt_toolkit-3.0.45-py3-none-any.whl", hash = "sha256:a29b89160e494e3ea8622b09fa5897610b437884dcdcd054fdc1308883326c2a"},
-    {file = "prompt_toolkit-3.0.45.tar.gz", hash = "sha256:07c60ee4ab7b7e90824b61afa840c8f5aad2d46b3e2e10acc33d8ecc94a49089"},
+    {file = "prompt_toolkit-3.0.47-py3-none-any.whl", hash = "sha256:0d7bfa67001d5e39d02c224b663abc33687405033a8c422d0d675a5a13361d10"},
+    {file = "prompt_toolkit-3.0.47.tar.gz", hash = "sha256:1e1b29cb58080b1e69f207c893a1a7bf16d127a5c30c9d17a25a5d77792e5360"},
 ]
 
 [package.dependencies]
@@ -1534,28 +1706,52 @@ with-pyroma = ["pyroma (>=2.4)"]
 with-vulture = ["vulture (>=1.5)"]
 
 [[package]]
+name = "protobuf"
+version = "4.21.12"
+description = ""
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "protobuf-4.21.12-cp310-abi3-win32.whl", hash = "sha256:b135410244ebe777db80298297a97fbb4c862c881b4403b71bac9d4107d61fd1"},
+    {file = "protobuf-4.21.12-cp310-abi3-win_amd64.whl", hash = "sha256:89f9149e4a0169cddfc44c74f230d7743002e3aa0b9472d8c28f0388102fc4c2"},
+    {file = "protobuf-4.21.12-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:299ea899484ee6f44604deb71f424234f654606b983cb496ea2a53e3c63ab791"},
+    {file = "protobuf-4.21.12-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:d1736130bce8cf131ac7957fa26880ca19227d4ad68b4888b3be0dea1f95df97"},
+    {file = "protobuf-4.21.12-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:78a28c9fa223998472886c77042e9b9afb6fe4242bd2a2a5aced88e3f4422aa7"},
+    {file = "protobuf-4.21.12-cp37-cp37m-win32.whl", hash = "sha256:3d164928ff0727d97022957c2b849250ca0e64777ee31efd7d6de2e07c494717"},
+    {file = "protobuf-4.21.12-cp37-cp37m-win_amd64.whl", hash = "sha256:f45460f9ee70a0ec1b6694c6e4e348ad2019275680bd68a1d9314b8c7e01e574"},
+    {file = "protobuf-4.21.12-cp38-cp38-win32.whl", hash = "sha256:6ab80df09e3208f742c98443b6166bcb70d65f52cfeb67357d52032ea1ae9bec"},
+    {file = "protobuf-4.21.12-cp38-cp38-win_amd64.whl", hash = "sha256:1f22ac0ca65bb70a876060d96d914dae09ac98d114294f77584b0d2644fa9c30"},
+    {file = "protobuf-4.21.12-cp39-cp39-win32.whl", hash = "sha256:27f4d15021da6d2b706ddc3860fac0a5ddaba34ab679dc182b60a8bb4e1121cc"},
+    {file = "protobuf-4.21.12-cp39-cp39-win_amd64.whl", hash = "sha256:237216c3326d46808a9f7c26fd1bd4b20015fb6867dc5d263a493ef9a539293b"},
+    {file = "protobuf-4.21.12-py2.py3-none-any.whl", hash = "sha256:a53fd3f03e578553623272dc46ac2f189de23862e68565e83dde203d41b76fc5"},
+    {file = "protobuf-4.21.12-py3-none-any.whl", hash = "sha256:b98d0148f84e3a3c569e19f52103ca1feacdac0d2df8d6533cf983d1fda28462"},
+    {file = "protobuf-4.21.12.tar.gz", hash = "sha256:7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab"},
+]
+
+[[package]]
 name = "psutil"
-version = "5.9.8"
+version = "6.0.0"
 description = "Cross-platform lib for process and system monitoring in Python."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
-    {file = "psutil-5.9.8-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:26bd09967ae00920df88e0352a91cff1a78f8d69b3ecabbfe733610c0af486c8"},
-    {file = "psutil-5.9.8-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:05806de88103b25903dff19bb6692bd2e714ccf9e668d050d144012055cbca73"},
-    {file = "psutil-5.9.8-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:611052c4bc70432ec770d5d54f64206aa7203a101ec273a0cd82418c86503bb7"},
-    {file = "psutil-5.9.8-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:50187900d73c1381ba1454cf40308c2bf6f34268518b3f36a9b663ca87e65e36"},
-    {file = "psutil-5.9.8-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:02615ed8c5ea222323408ceba16c60e99c3f91639b07da6373fb7e6539abc56d"},
-    {file = "psutil-5.9.8-cp27-none-win32.whl", hash = "sha256:36f435891adb138ed3c9e58c6af3e2e6ca9ac2f365efe1f9cfef2794e6c93b4e"},
-    {file = "psutil-5.9.8-cp27-none-win_amd64.whl", hash = "sha256:bd1184ceb3f87651a67b2708d4c3338e9b10c5df903f2e3776b62303b26cb631"},
-    {file = "psutil-5.9.8-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aee678c8720623dc456fa20659af736241f575d79429a0e5e9cf88ae0605cc81"},
-    {file = "psutil-5.9.8-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cb6403ce6d8e047495a701dc7c5bd788add903f8986d523e3e20b98b733e421"},
-    {file = "psutil-5.9.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d06016f7f8625a1825ba3732081d77c94589dca78b7a3fc072194851e88461a4"},
-    {file = "psutil-5.9.8-cp36-cp36m-win32.whl", hash = "sha256:7d79560ad97af658a0f6adfef8b834b53f64746d45b403f225b85c5c2c140eee"},
-    {file = "psutil-5.9.8-cp36-cp36m-win_amd64.whl", hash = "sha256:27cc40c3493bb10de1be4b3f07cae4c010ce715290a5be22b98493509c6299e2"},
-    {file = "psutil-5.9.8-cp37-abi3-win32.whl", hash = "sha256:bc56c2a1b0d15aa3eaa5a60c9f3f8e3e565303b465dbf57a1b730e7a2b9844e0"},
-    {file = "psutil-5.9.8-cp37-abi3-win_amd64.whl", hash = "sha256:8db4c1b57507eef143a15a6884ca10f7c73876cdf5d51e713151c1236a0e68cf"},
-    {file = "psutil-5.9.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d16bbddf0693323b8c6123dd804100241da461e41d6e332fb0ba6058f630f8c8"},
-    {file = "psutil-5.9.8.tar.gz", hash = "sha256:6be126e3225486dff286a8fb9a06246a5253f4c7c53b475ea5f5ac934e64194c"},
+    {file = "psutil-6.0.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a021da3e881cd935e64a3d0a20983bda0bb4cf80e4f74fa9bfcb1bc5785360c6"},
+    {file = "psutil-6.0.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:1287c2b95f1c0a364d23bc6f2ea2365a8d4d9b726a3be7294296ff7ba97c17f0"},
+    {file = "psutil-6.0.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:a9a3dbfb4de4f18174528d87cc352d1f788b7496991cca33c6996f40c9e3c92c"},
+    {file = "psutil-6.0.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:6ec7588fb3ddaec7344a825afe298db83fe01bfaaab39155fa84cf1c0d6b13c3"},
+    {file = "psutil-6.0.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:1e7c870afcb7d91fdea2b37c24aeb08f98b6d67257a5cb0a8bc3ac68d0f1a68c"},
+    {file = "psutil-6.0.0-cp27-none-win32.whl", hash = "sha256:02b69001f44cc73c1c5279d02b30a817e339ceb258ad75997325e0e6169d8b35"},
+    {file = "psutil-6.0.0-cp27-none-win_amd64.whl", hash = "sha256:21f1fb635deccd510f69f485b87433460a603919b45e2a324ad65b0cc74f8fb1"},
+    {file = "psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2e8d0054fc88153ca0544f5c4d554d42e33df2e009c4ff42284ac9ebdef4132"},
+    {file = "psutil-6.0.0-cp36-cp36m-win32.whl", hash = "sha256:fc8c9510cde0146432bbdb433322861ee8c3efbf8589865c8bf8d21cb30c4d14"},
+    {file = "psutil-6.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:34859b8d8f423b86e4385ff3665d3f4d94be3cdf48221fbe476e883514fdb71c"},
+    {file = "psutil-6.0.0-cp37-abi3-win32.whl", hash = "sha256:a495580d6bae27291324fe60cea0b5a7c23fa36a7cd35035a16d93bdcf076b9d"},
+    {file = "psutil-6.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:33ea5e1c975250a720b3a6609c490db40dae5d83a4eb315170c4fe0d8b1f34b3"},
+    {file = "psutil-6.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ffe7fc9b6b36beadc8c322f84e1caff51e8703b88eee1da46d1e3a6ae11b4fd0"},
+    {file = "psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2"},
 ]
 
 [package.extras]
@@ -1574,13 +1770,13 @@ files = [
 
 [[package]]
 name = "pure-eval"
-version = "0.2.2"
+version = "0.2.3"
 description = "Safely evaluate AST nodes without side effects"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pure_eval-0.2.2-py3-none-any.whl", hash = "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350"},
-    {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
+    {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
+    {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
 ]
 
 [package.extras]
@@ -1596,6 +1792,48 @@ files = [
     {file = "py4j-0.10.9.7-py2.py3-none-any.whl", hash = "sha256:85defdfd2b2376eb3abf5ca6474b51ab7e0de341c75a02f46dc9b5976f5a5c1b"},
     {file = "py4j-0.10.9.7.tar.gz", hash = "sha256:0b6e5315bb3ada5cf62ac651d107bb2ebc02def3dee9d9548e3baac644ea8dbb"},
 ]
+
+[[package]]
+name = "pyarrow"
+version = "7.0.0"
+description = "Python library for Apache Arrow"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyarrow-7.0.0-cp310-cp310-macosx_10_13_universal2.whl", hash = "sha256:0f15213f380539c9640cb2413dc677b55e70f04c9e98cfc2e1d8b36c770e1036"},
+    {file = "pyarrow-7.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:29c4e3b3be0b94d07ff4921a5e410fc690a3a066a850a302fc504de5fc638495"},
+    {file = "pyarrow-7.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8a9bfc8a016bcb8f9a8536d2fa14a890b340bc7a236275cd60fd4fb8b93ff405"},
+    {file = "pyarrow-7.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:49d431ed644a3e8f53ae2bbf4b514743570b495b5829548db51610534b6eeee7"},
+    {file = "pyarrow-7.0.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:aa6442a321c1e49480b3d436f7d631c895048a16df572cf71c23c6b53c45ed66"},
+    {file = "pyarrow-7.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6b01a23cb401750092c6f7c4dcae67cd8fd6b99ae710e26f654f23508f25f25"},
+    {file = "pyarrow-7.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f10928745c6ff66e121552731409803bed86c66ac79c64c90438b053b5242c5"},
+    {file = "pyarrow-7.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:759090caa1474cafb5e68c93a9bd6cb45d8bb8e4f2cad2f1a0cc9439bae8ae88"},
+    {file = "pyarrow-7.0.0-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:e3fe34bcfc28d9c4a747adc3926d2307a04c5c50b89155946739515ccfe5eab0"},
+    {file = "pyarrow-7.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:040dce5345603e4e621bcf4f3b21f18d557852e7b15307e559bb14c8951c8714"},
+    {file = "pyarrow-7.0.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ed4b647c3345ae3463d341a9d28d0260cd302fb92ecf4e2e3e0f1656d6e0e55c"},
+    {file = "pyarrow-7.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7fecd5d5604f47e003f50887a42aee06cb8b7bf8e8bf7dc543a22331d9ba832"},
+    {file = "pyarrow-7.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f2d00b892fe865e43346acb78761ba268f8bb1cbdba588816590abcb780ee3d"},
+    {file = "pyarrow-7.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:f439f7d77201681fd31391d189aa6b1322d27c9311a8f2fce7d23972471b02b6"},
+    {file = "pyarrow-7.0.0-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:3e06b0e29ce1e32f219c670c6b31c33d25a5b8e29c7828f873373aab78bf30a5"},
+    {file = "pyarrow-7.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:13dc05bcf79dbc1bd2de1b05d26eb64824b85883d019d81ca3c2eca9b68b5a44"},
+    {file = "pyarrow-7.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:06183a7ff2b0c030ec0413fc4dc98abad8cf336c78c280a0b7f4bcbebb78d125"},
+    {file = "pyarrow-7.0.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:702c5a9f960b56d03569eaaca2c1a05e8728f05ea1a2138ef64234aa53cd5884"},
+    {file = "pyarrow-7.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7313038203df77ec4092d6363dbc0945071caa72635f365f2b1ae0dd7469865"},
+    {file = "pyarrow-7.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e87d1f7dc7a0b2ecaeb0c7a883a85710f5b5626d4134454f905571c04bc73d5a"},
+    {file = "pyarrow-7.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:ba69488ae25c7fde1a2ae9ea29daf04d676de8960ffd6f82e1e13ca945bb5861"},
+    {file = "pyarrow-7.0.0-cp39-cp39-macosx_10_13_universal2.whl", hash = "sha256:11a591f11d2697c751261c9d57e6e5b0d38fdc7f0cc57f4fd6edc657da7737df"},
+    {file = "pyarrow-7.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:6183c700877852dc0f8a76d4c0c2ffd803ba459e2b4a452e355c2d58d48cf39f"},
+    {file = "pyarrow-7.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1748154714b543e6ae8452a68d4af85caf5298296a7e5d4d00f1b3021838ac6"},
+    {file = "pyarrow-7.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcc8f934c7847a88f13ec35feecffb61fe63bb7a3078bd98dd353762e969ce60"},
+    {file = "pyarrow-7.0.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:759f59ac77b84878dbd54d06cf6df74ff781b8e7cf9313eeffbb5ec97b94385c"},
+    {file = "pyarrow-7.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d3e3f93ac2993df9c5e1922eab7bdea047b9da918a74e52145399bc1f0099a3"},
+    {file = "pyarrow-7.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:306120af554e7e137895254a3b4741fad682875a5f6403509cd276de3fe5b844"},
+    {file = "pyarrow-7.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:087769dac6e567d58d59b94c4f866b3356c00d3db5b261387ece47e7324c2150"},
+    {file = "pyarrow-7.0.0.tar.gz", hash = "sha256:da656cad3c23a2ebb6a307ab01d35fce22f7850059cffafcb90d12590f8f4f38"},
+]
+
+[package.dependencies]
+numpy = ">=1.16.6"
 
 [[package]]
 name = "pycodestyle"
@@ -1771,23 +2009,23 @@ extra = ["pygments (>=2.12)"]
 
 [[package]]
 name = "pyspark"
-version = "3.4.3"
+version = "3.5.2"
 description = "Apache Spark Python API"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pyspark-3.4.3.tar.gz", hash = "sha256:8d7025fa274830cb6c3bd592228be3d9345cb3b8b1e324018c2aa6e75f48a208"},
+    {file = "pyspark-3.5.2.tar.gz", hash = "sha256:bbb36eba09fa24e86e0923d7e7a986041b90c714e11c6aa976f9791fe9edde5e"},
 ]
 
 [package.dependencies]
 py4j = "0.10.9.7"
 
 [package.extras]
-connect = ["googleapis-common-protos (>=1.56.4)", "grpcio (>=1.48.1)", "grpcio-status (>=1.48.1)", "numpy (>=1.15)", "pandas (>=1.0.5)", "pyarrow (>=1.0.0)"]
-ml = ["numpy (>=1.15)"]
-mllib = ["numpy (>=1.15)"]
-pandas-on-spark = ["numpy (>=1.15)", "pandas (>=1.0.5)", "pyarrow (>=1.0.0)"]
-sql = ["numpy (>=1.15)", "pandas (>=1.0.5)", "pyarrow (>=1.0.0)"]
+connect = ["googleapis-common-protos (>=1.56.4)", "grpcio (>=1.56.0)", "grpcio-status (>=1.56.0)", "numpy (>=1.15,<2)", "pandas (>=1.0.5)", "pyarrow (>=4.0.0)"]
+ml = ["numpy (>=1.15,<2)"]
+mllib = ["numpy (>=1.15,<2)"]
+pandas-on-spark = ["numpy (>=1.15,<2)", "pandas (>=1.0.5)", "pyarrow (>=4.0.0)"]
+sql = ["numpy (>=1.15,<2)", "pandas (>=1.0.5)", "pyarrow (>=4.0.0)"]
 
 [[package]]
 name = "pytest"
@@ -1843,6 +2081,17 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "pytz"
+version = "2024.2"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
+    {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
+]
+
+[[package]]
 name = "pywin32"
 version = "306"
 description = "Python for Window Extensions"
@@ -1867,51 +2116,64 @@ files = [
 
 [[package]]
 name = "pyyaml"
-version = "6.0.1"
+version = "6.0.2"
 description = "YAML parser and emitter for Python"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
-    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
-    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
 ]
 
 [[package]]
@@ -1930,99 +2192,120 @@ pyyaml = "*"
 
 [[package]]
 name = "pyzmq"
-version = "26.0.3"
+version = "26.2.0"
 description = "Python bindings for 0MQ"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyzmq-26.0.3-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:44dd6fc3034f1eaa72ece33588867df9e006a7303725a12d64c3dff92330f625"},
-    {file = "pyzmq-26.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:acb704195a71ac5ea5ecf2811c9ee19ecdc62b91878528302dd0be1b9451cc90"},
-    {file = "pyzmq-26.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dbb9c997932473a27afa93954bb77a9f9b786b4ccf718d903f35da3232317de"},
-    {file = "pyzmq-26.0.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6bcb34f869d431799c3ee7d516554797f7760cb2198ecaa89c3f176f72d062be"},
-    {file = "pyzmq-26.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38ece17ec5f20d7d9b442e5174ae9f020365d01ba7c112205a4d59cf19dc38ee"},
-    {file = "pyzmq-26.0.3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ba6e5e6588e49139a0979d03a7deb9c734bde647b9a8808f26acf9c547cab1bf"},
-    {file = "pyzmq-26.0.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3bf8b000a4e2967e6dfdd8656cd0757d18c7e5ce3d16339e550bd462f4857e59"},
-    {file = "pyzmq-26.0.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:2136f64fbb86451dbbf70223635a468272dd20075f988a102bf8a3f194a411dc"},
-    {file = "pyzmq-26.0.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e8918973fbd34e7814f59143c5f600ecd38b8038161239fd1a3d33d5817a38b8"},
-    {file = "pyzmq-26.0.3-cp310-cp310-win32.whl", hash = "sha256:0aaf982e68a7ac284377d051c742610220fd06d330dcd4c4dbb4cdd77c22a537"},
-    {file = "pyzmq-26.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:f1a9b7d00fdf60b4039f4455afd031fe85ee8305b019334b72dcf73c567edc47"},
-    {file = "pyzmq-26.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:80b12f25d805a919d53efc0a5ad7c0c0326f13b4eae981a5d7b7cc343318ebb7"},
-    {file = "pyzmq-26.0.3-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:a72a84570f84c374b4c287183debc776dc319d3e8ce6b6a0041ce2e400de3f32"},
-    {file = "pyzmq-26.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7ca684ee649b55fd8f378127ac8462fb6c85f251c2fb027eb3c887e8ee347bcd"},
-    {file = "pyzmq-26.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e222562dc0f38571c8b1ffdae9d7adb866363134299264a1958d077800b193b7"},
-    {file = "pyzmq-26.0.3-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f17cde1db0754c35a91ac00b22b25c11da6eec5746431d6e5092f0cd31a3fea9"},
-    {file = "pyzmq-26.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b7c0c0b3244bb2275abe255d4a30c050d541c6cb18b870975553f1fb6f37527"},
-    {file = "pyzmq-26.0.3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac97a21de3712afe6a6c071abfad40a6224fd14fa6ff0ff8d0c6e6cd4e2f807a"},
-    {file = "pyzmq-26.0.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:88b88282e55fa39dd556d7fc04160bcf39dea015f78e0cecec8ff4f06c1fc2b5"},
-    {file = "pyzmq-26.0.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:72b67f966b57dbd18dcc7efbc1c7fc9f5f983e572db1877081f075004614fcdd"},
-    {file = "pyzmq-26.0.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f4b6cecbbf3b7380f3b61de3a7b93cb721125dc125c854c14ddc91225ba52f83"},
-    {file = "pyzmq-26.0.3-cp311-cp311-win32.whl", hash = "sha256:eed56b6a39216d31ff8cd2f1d048b5bf1700e4b32a01b14379c3b6dde9ce3aa3"},
-    {file = "pyzmq-26.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:3191d312c73e3cfd0f0afdf51df8405aafeb0bad71e7ed8f68b24b63c4f36500"},
-    {file = "pyzmq-26.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:b6907da3017ef55139cf0e417c5123a84c7332520e73a6902ff1f79046cd3b94"},
-    {file = "pyzmq-26.0.3-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:068ca17214038ae986d68f4a7021f97e187ed278ab6dccb79f837d765a54d753"},
-    {file = "pyzmq-26.0.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:7821d44fe07335bea256b9f1f41474a642ca55fa671dfd9f00af8d68a920c2d4"},
-    {file = "pyzmq-26.0.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eeb438a26d87c123bb318e5f2b3d86a36060b01f22fbdffd8cf247d52f7c9a2b"},
-    {file = "pyzmq-26.0.3-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:69ea9d6d9baa25a4dc9cef5e2b77b8537827b122214f210dd925132e34ae9b12"},
-    {file = "pyzmq-26.0.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7daa3e1369355766dea11f1d8ef829905c3b9da886ea3152788dc25ee6079e02"},
-    {file = "pyzmq-26.0.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6ca7a9a06b52d0e38ccf6bca1aeff7be178917893f3883f37b75589d42c4ac20"},
-    {file = "pyzmq-26.0.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:1b7d0e124948daa4d9686d421ef5087c0516bc6179fdcf8828b8444f8e461a77"},
-    {file = "pyzmq-26.0.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:e746524418b70f38550f2190eeee834db8850088c834d4c8406fbb9bc1ae10b2"},
-    {file = "pyzmq-26.0.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:6b3146f9ae6af82c47a5282ac8803523d381b3b21caeae0327ed2f7ecb718798"},
-    {file = "pyzmq-26.0.3-cp312-cp312-win32.whl", hash = "sha256:2b291d1230845871c00c8462c50565a9cd6026fe1228e77ca934470bb7d70ea0"},
-    {file = "pyzmq-26.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:926838a535c2c1ea21c903f909a9a54e675c2126728c21381a94ddf37c3cbddf"},
-    {file = "pyzmq-26.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:5bf6c237f8c681dfb91b17f8435b2735951f0d1fad10cc5dfd96db110243370b"},
-    {file = "pyzmq-26.0.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0c0991f5a96a8e620f7691e61178cd8f457b49e17b7d9cfa2067e2a0a89fc1d5"},
-    {file = "pyzmq-26.0.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:dbf012d8fcb9f2cf0643b65df3b355fdd74fc0035d70bb5c845e9e30a3a4654b"},
-    {file = "pyzmq-26.0.3-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:01fbfbeb8249a68d257f601deb50c70c929dc2dfe683b754659569e502fbd3aa"},
-    {file = "pyzmq-26.0.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c8eb19abe87029c18f226d42b8a2c9efdd139d08f8bf6e085dd9075446db450"},
-    {file = "pyzmq-26.0.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:5344b896e79800af86ad643408ca9aa303a017f6ebff8cee5a3163c1e9aec987"},
-    {file = "pyzmq-26.0.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:204e0f176fd1d067671157d049466869b3ae1fc51e354708b0dc41cf94e23a3a"},
-    {file = "pyzmq-26.0.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a42db008d58530efa3b881eeee4991146de0b790e095f7ae43ba5cc612decbc5"},
-    {file = "pyzmq-26.0.3-cp37-cp37m-win32.whl", hash = "sha256:8d7a498671ca87e32b54cb47c82a92b40130a26c5197d392720a1bce1b3c77cf"},
-    {file = "pyzmq-26.0.3-cp37-cp37m-win_amd64.whl", hash = "sha256:3b4032a96410bdc760061b14ed6a33613ffb7f702181ba999df5d16fb96ba16a"},
-    {file = "pyzmq-26.0.3-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:2cc4e280098c1b192c42a849de8de2c8e0f3a84086a76ec5b07bfee29bda7d18"},
-    {file = "pyzmq-26.0.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5bde86a2ed3ce587fa2b207424ce15b9a83a9fa14422dcc1c5356a13aed3df9d"},
-    {file = "pyzmq-26.0.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:34106f68e20e6ff253c9f596ea50397dbd8699828d55e8fa18bd4323d8d966e6"},
-    {file = "pyzmq-26.0.3-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ebbbd0e728af5db9b04e56389e2299a57ea8b9dd15c9759153ee2455b32be6ad"},
-    {file = "pyzmq-26.0.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6b1d1c631e5940cac5a0b22c5379c86e8df6a4ec277c7a856b714021ab6cfad"},
-    {file = "pyzmq-26.0.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e891ce81edd463b3b4c3b885c5603c00141151dd9c6936d98a680c8c72fe5c67"},
-    {file = "pyzmq-26.0.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9b273ecfbc590a1b98f014ae41e5cf723932f3b53ba9367cfb676f838038b32c"},
-    {file = "pyzmq-26.0.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b32bff85fb02a75ea0b68f21e2412255b5731f3f389ed9aecc13a6752f58ac97"},
-    {file = "pyzmq-26.0.3-cp38-cp38-win32.whl", hash = "sha256:f6c21c00478a7bea93caaaef9e7629145d4153b15a8653e8bb4609d4bc70dbfc"},
-    {file = "pyzmq-26.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:3401613148d93ef0fd9aabdbddb212de3db7a4475367f49f590c837355343972"},
-    {file = "pyzmq-26.0.3-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:2ed8357f4c6e0daa4f3baf31832df8a33334e0fe5b020a61bc8b345a3db7a606"},
-    {file = "pyzmq-26.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c1c8f2a2ca45292084c75bb6d3a25545cff0ed931ed228d3a1810ae3758f975f"},
-    {file = "pyzmq-26.0.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:b63731993cdddcc8e087c64e9cf003f909262b359110070183d7f3025d1c56b5"},
-    {file = "pyzmq-26.0.3-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b3cd31f859b662ac5d7f4226ec7d8bd60384fa037fc02aee6ff0b53ba29a3ba8"},
-    {file = "pyzmq-26.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:115f8359402fa527cf47708d6f8a0f8234f0e9ca0cab7c18c9c189c194dbf620"},
-    {file = "pyzmq-26.0.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:715bdf952b9533ba13dfcf1f431a8f49e63cecc31d91d007bc1deb914f47d0e4"},
-    {file = "pyzmq-26.0.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e1258c639e00bf5e8a522fec6c3eaa3e30cf1c23a2f21a586be7e04d50c9acab"},
-    {file = "pyzmq-26.0.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:15c59e780be8f30a60816a9adab900c12a58d79c1ac742b4a8df044ab2a6d920"},
-    {file = "pyzmq-26.0.3-cp39-cp39-win32.whl", hash = "sha256:d0cdde3c78d8ab5b46595054e5def32a755fc028685add5ddc7403e9f6de9879"},
-    {file = "pyzmq-26.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:ce828058d482ef860746bf532822842e0ff484e27f540ef5c813d516dd8896d2"},
-    {file = "pyzmq-26.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:788f15721c64109cf720791714dc14afd0f449d63f3a5487724f024345067381"},
-    {file = "pyzmq-26.0.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2c18645ef6294d99b256806e34653e86236eb266278c8ec8112622b61db255de"},
-    {file = "pyzmq-26.0.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7e6bc96ebe49604df3ec2c6389cc3876cabe475e6bfc84ced1bf4e630662cb35"},
-    {file = "pyzmq-26.0.3-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:971e8990c5cc4ddcff26e149398fc7b0f6a042306e82500f5e8db3b10ce69f84"},
-    {file = "pyzmq-26.0.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8416c23161abd94cc7da80c734ad7c9f5dbebdadfdaa77dad78244457448223"},
-    {file = "pyzmq-26.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:082a2988364b60bb5de809373098361cf1dbb239623e39e46cb18bc035ed9c0c"},
-    {file = "pyzmq-26.0.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:d57dfbf9737763b3a60d26e6800e02e04284926329aee8fb01049635e957fe81"},
-    {file = "pyzmq-26.0.3-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:77a85dca4c2430ac04dc2a2185c2deb3858a34fe7f403d0a946fa56970cf60a1"},
-    {file = "pyzmq-26.0.3-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4c82a6d952a1d555bf4be42b6532927d2a5686dd3c3e280e5f63225ab47ac1f5"},
-    {file = "pyzmq-26.0.3-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4496b1282c70c442809fc1b151977c3d967bfb33e4e17cedbf226d97de18f709"},
-    {file = "pyzmq-26.0.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:e4946d6bdb7ba972dfda282f9127e5756d4f299028b1566d1245fa0d438847e6"},
-    {file = "pyzmq-26.0.3-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:03c0ae165e700364b266876d712acb1ac02693acd920afa67da2ebb91a0b3c09"},
-    {file = "pyzmq-26.0.3-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:3e3070e680f79887d60feeda051a58d0ac36622e1759f305a41059eff62c6da7"},
-    {file = "pyzmq-26.0.3-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6ca08b840fe95d1c2bd9ab92dac5685f949fc6f9ae820ec16193e5ddf603c3b2"},
-    {file = "pyzmq-26.0.3-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e76654e9dbfb835b3518f9938e565c7806976c07b37c33526b574cc1a1050480"},
-    {file = "pyzmq-26.0.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:871587bdadd1075b112e697173e946a07d722459d20716ceb3d1bd6c64bd08ce"},
-    {file = "pyzmq-26.0.3-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:d0a2d1bd63a4ad79483049b26514e70fa618ce6115220da9efdff63688808b17"},
-    {file = "pyzmq-26.0.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0270b49b6847f0d106d64b5086e9ad5dc8a902413b5dbbb15d12b60f9c1747a4"},
-    {file = "pyzmq-26.0.3-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:703c60b9910488d3d0954ca585c34f541e506a091a41930e663a098d3b794c67"},
-    {file = "pyzmq-26.0.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74423631b6be371edfbf7eabb02ab995c2563fee60a80a30829176842e71722a"},
-    {file = "pyzmq-26.0.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4adfbb5451196842a88fda3612e2c0414134874bffb1c2ce83ab4242ec9e027d"},
-    {file = "pyzmq-26.0.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:3516119f4f9b8671083a70b6afaa0a070f5683e431ab3dc26e9215620d7ca1ad"},
-    {file = "pyzmq-26.0.3.tar.gz", hash = "sha256:dba7d9f2e047dfa2bca3b01f4f84aa5246725203d6284e3790f2ca15fba6b40a"},
+    {file = "pyzmq-26.2.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:ddf33d97d2f52d89f6e6e7ae66ee35a4d9ca6f36eda89c24591b0c40205a3629"},
+    {file = "pyzmq-26.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dacd995031a01d16eec825bf30802fceb2c3791ef24bcce48fa98ce40918c27b"},
+    {file = "pyzmq-26.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89289a5ee32ef6c439086184529ae060c741334b8970a6855ec0b6ad3ff28764"},
+    {file = "pyzmq-26.2.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5506f06d7dc6ecf1efacb4a013b1f05071bb24b76350832c96449f4a2d95091c"},
+    {file = "pyzmq-26.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ea039387c10202ce304af74def5021e9adc6297067f3441d348d2b633e8166a"},
+    {file = "pyzmq-26.2.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a2224fa4a4c2ee872886ed00a571f5e967c85e078e8e8c2530a2fb01b3309b88"},
+    {file = "pyzmq-26.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:28ad5233e9c3b52d76196c696e362508959741e1a005fb8fa03b51aea156088f"},
+    {file = "pyzmq-26.2.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:1c17211bc037c7d88e85ed8b7d8f7e52db6dc8eca5590d162717c654550f7282"},
+    {file = "pyzmq-26.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b8f86dd868d41bea9a5f873ee13bf5551c94cf6bc51baebc6f85075971fe6eea"},
+    {file = "pyzmq-26.2.0-cp310-cp310-win32.whl", hash = "sha256:46a446c212e58456b23af260f3d9fb785054f3e3653dbf7279d8f2b5546b21c2"},
+    {file = "pyzmq-26.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:49d34ab71db5a9c292a7644ce74190b1dd5a3475612eefb1f8be1d6961441971"},
+    {file = "pyzmq-26.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:bfa832bfa540e5b5c27dcf5de5d82ebc431b82c453a43d141afb1e5d2de025fa"},
+    {file = "pyzmq-26.2.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:8f7e66c7113c684c2b3f1c83cdd3376103ee0ce4c49ff80a648643e57fb22218"},
+    {file = "pyzmq-26.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3a495b30fc91db2db25120df5847d9833af237546fd59170701acd816ccc01c4"},
+    {file = "pyzmq-26.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77eb0968da535cba0470a5165468b2cac7772cfb569977cff92e240f57e31bef"},
+    {file = "pyzmq-26.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ace4f71f1900a548f48407fc9be59c6ba9d9aaf658c2eea6cf2779e72f9f317"},
+    {file = "pyzmq-26.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92a78853d7280bffb93df0a4a6a2498cba10ee793cc8076ef797ef2f74d107cf"},
+    {file = "pyzmq-26.2.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:689c5d781014956a4a6de61d74ba97b23547e431e9e7d64f27d4922ba96e9d6e"},
+    {file = "pyzmq-26.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0aca98bc423eb7d153214b2df397c6421ba6373d3397b26c057af3c904452e37"},
+    {file = "pyzmq-26.2.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1f3496d76b89d9429a656293744ceca4d2ac2a10ae59b84c1da9b5165f429ad3"},
+    {file = "pyzmq-26.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5c2b3bfd4b9689919db068ac6c9911f3fcb231c39f7dd30e3138be94896d18e6"},
+    {file = "pyzmq-26.2.0-cp311-cp311-win32.whl", hash = "sha256:eac5174677da084abf378739dbf4ad245661635f1600edd1221f150b165343f4"},
+    {file = "pyzmq-26.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:5a509df7d0a83a4b178d0f937ef14286659225ef4e8812e05580776c70e155d5"},
+    {file = "pyzmq-26.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:c0e6091b157d48cbe37bd67233318dbb53e1e6327d6fc3bb284afd585d141003"},
+    {file = "pyzmq-26.2.0-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:ded0fc7d90fe93ae0b18059930086c51e640cdd3baebdc783a695c77f123dcd9"},
+    {file = "pyzmq-26.2.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:17bf5a931c7f6618023cdacc7081f3f266aecb68ca692adac015c383a134ca52"},
+    {file = "pyzmq-26.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55cf66647e49d4621a7e20c8d13511ef1fe1efbbccf670811864452487007e08"},
+    {file = "pyzmq-26.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4661c88db4a9e0f958c8abc2b97472e23061f0bc737f6f6179d7a27024e1faa5"},
+    {file = "pyzmq-26.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea7f69de383cb47522c9c208aec6dd17697db7875a4674c4af3f8cfdac0bdeae"},
+    {file = "pyzmq-26.2.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7f98f6dfa8b8ccaf39163ce872bddacca38f6a67289116c8937a02e30bbe9711"},
+    {file = "pyzmq-26.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e3e0210287329272539eea617830a6a28161fbbd8a3271bf4150ae3e58c5d0e6"},
+    {file = "pyzmq-26.2.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:6b274e0762c33c7471f1a7471d1a2085b1a35eba5cdc48d2ae319f28b6fc4de3"},
+    {file = "pyzmq-26.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:29c6a4635eef69d68a00321e12a7d2559fe2dfccfa8efae3ffb8e91cd0b36a8b"},
+    {file = "pyzmq-26.2.0-cp312-cp312-win32.whl", hash = "sha256:989d842dc06dc59feea09e58c74ca3e1678c812a4a8a2a419046d711031f69c7"},
+    {file = "pyzmq-26.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:2a50625acdc7801bc6f74698c5c583a491c61d73c6b7ea4dee3901bb99adb27a"},
+    {file = "pyzmq-26.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d29ab8592b6ad12ebbf92ac2ed2bedcfd1cec192d8e559e2e099f648570e19b"},
+    {file = "pyzmq-26.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9dd8cd1aeb00775f527ec60022004d030ddc51d783d056e3e23e74e623e33726"},
+    {file = "pyzmq-26.2.0-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:28c812d9757fe8acecc910c9ac9dafd2ce968c00f9e619db09e9f8f54c3a68a3"},
+    {file = "pyzmq-26.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d80b1dd99c1942f74ed608ddb38b181b87476c6a966a88a950c7dee118fdf50"},
+    {file = "pyzmq-26.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8c997098cc65e3208eca09303630e84d42718620e83b733d0fd69543a9cab9cb"},
+    {file = "pyzmq-26.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ad1bc8d1b7a18497dda9600b12dc193c577beb391beae5cd2349184db40f187"},
+    {file = "pyzmq-26.2.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:bea2acdd8ea4275e1278350ced63da0b166421928276c7c8e3f9729d7402a57b"},
+    {file = "pyzmq-26.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:23f4aad749d13698f3f7b64aad34f5fc02d6f20f05999eebc96b89b01262fb18"},
+    {file = "pyzmq-26.2.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:a4f96f0d88accc3dbe4a9025f785ba830f968e21e3e2c6321ccdfc9aef755115"},
+    {file = "pyzmq-26.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ced65e5a985398827cc9276b93ef6dfabe0273c23de8c7931339d7e141c2818e"},
+    {file = "pyzmq-26.2.0-cp313-cp313-win32.whl", hash = "sha256:31507f7b47cc1ead1f6e86927f8ebb196a0bab043f6345ce070f412a59bf87b5"},
+    {file = "pyzmq-26.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:70fc7fcf0410d16ebdda9b26cbd8bf8d803d220a7f3522e060a69a9c87bf7bad"},
+    {file = "pyzmq-26.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:c3789bd5768ab5618ebf09cef6ec2b35fed88709b104351748a63045f0ff9797"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:034da5fc55d9f8da09015d368f519478a52675e558c989bfcb5cf6d4e16a7d2a"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:c92d73464b886931308ccc45b2744e5968cbaade0b1d6aeb40d8ab537765f5bc"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:794a4562dcb374f7dbbfb3f51d28fb40123b5a2abadee7b4091f93054909add5"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aee22939bb6075e7afededabad1a56a905da0b3c4e3e0c45e75810ebe3a52672"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ae90ff9dad33a1cfe947d2c40cb9cb5e600d759ac4f0fd22616ce6540f72797"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:43a47408ac52647dfabbc66a25b05b6a61700b5165807e3fbd40063fcaf46386"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:25bf2374a2a8433633c65ccb9553350d5e17e60c8eb4de4d92cc6bd60f01d306"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-musllinux_1_1_i686.whl", hash = "sha256:007137c9ac9ad5ea21e6ad97d3489af654381324d5d3ba614c323f60dab8fae6"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:470d4a4f6d48fb34e92d768b4e8a5cc3780db0d69107abf1cd7ff734b9766eb0"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3b55a4229ce5da9497dd0452b914556ae58e96a4381bb6f59f1305dfd7e53fc8"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9cb3a6460cdea8fe8194a76de8895707e61ded10ad0be97188cc8463ffa7e3a8"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8ab5cad923cc95c87bffee098a27856c859bd5d0af31bd346035aa816b081fe1"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ed69074a610fad1c2fda66180e7b2edd4d31c53f2d1872bc2d1211563904cd9"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cccba051221b916a4f5e538997c45d7d136a5646442b1231b916d0164067ea27"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:0eaa83fc4c1e271c24eaf8fb083cbccef8fde77ec8cd45f3c35a9a123e6da097"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:9edda2df81daa129b25a39b86cb57dfdfe16f7ec15b42b19bfac503360d27a93"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-win32.whl", hash = "sha256:ea0eb6af8a17fa272f7b98d7bebfab7836a0d62738e16ba380f440fceca2d951"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4ff9dc6bc1664bb9eec25cd17506ef6672d506115095411e237d571e92a58231"},
+    {file = "pyzmq-26.2.0-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:2eb7735ee73ca1b0d71e0e67c3739c689067f055c764f73aac4cc8ecf958ee3f"},
+    {file = "pyzmq-26.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1a534f43bc738181aa7cbbaf48e3eca62c76453a40a746ab95d4b27b1111a7d2"},
+    {file = "pyzmq-26.2.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:aedd5dd8692635813368e558a05266b995d3d020b23e49581ddd5bbe197a8ab6"},
+    {file = "pyzmq-26.2.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8be4700cd8bb02cc454f630dcdf7cfa99de96788b80c51b60fe2fe1dac480289"},
+    {file = "pyzmq-26.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fcc03fa4997c447dce58264e93b5aa2d57714fbe0f06c07b7785ae131512732"},
+    {file = "pyzmq-26.2.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:402b190912935d3db15b03e8f7485812db350d271b284ded2b80d2e5704be780"},
+    {file = "pyzmq-26.2.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8685fa9c25ff00f550c1fec650430c4b71e4e48e8d852f7ddcf2e48308038640"},
+    {file = "pyzmq-26.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:76589c020680778f06b7e0b193f4b6dd66d470234a16e1df90329f5e14a171cd"},
+    {file = "pyzmq-26.2.0-cp38-cp38-win32.whl", hash = "sha256:8423c1877d72c041f2c263b1ec6e34360448decfb323fa8b94e85883043ef988"},
+    {file = "pyzmq-26.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:76589f2cd6b77b5bdea4fca5992dc1c23389d68b18ccc26a53680ba2dc80ff2f"},
+    {file = "pyzmq-26.2.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:b1d464cb8d72bfc1a3adc53305a63a8e0cac6bc8c5a07e8ca190ab8d3faa43c2"},
+    {file = "pyzmq-26.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4da04c48873a6abdd71811c5e163bd656ee1b957971db7f35140a2d573f6949c"},
+    {file = "pyzmq-26.2.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d049df610ac811dcffdc147153b414147428567fbbc8be43bb8885f04db39d98"},
+    {file = "pyzmq-26.2.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05590cdbc6b902101d0e65d6a4780af14dc22914cc6ab995d99b85af45362cc9"},
+    {file = "pyzmq-26.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c811cfcd6a9bf680236c40c6f617187515269ab2912f3d7e8c0174898e2519db"},
+    {file = "pyzmq-26.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6835dd60355593de10350394242b5757fbbd88b25287314316f266e24c61d073"},
+    {file = "pyzmq-26.2.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bc6bee759a6bddea5db78d7dcd609397449cb2d2d6587f48f3ca613b19410cfc"},
+    {file = "pyzmq-26.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c530e1eecd036ecc83c3407f77bb86feb79916d4a33d11394b8234f3bd35b940"},
+    {file = "pyzmq-26.2.0-cp39-cp39-win32.whl", hash = "sha256:367b4f689786fca726ef7a6c5ba606958b145b9340a5e4808132cc65759abd44"},
+    {file = "pyzmq-26.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:e6fa2e3e683f34aea77de8112f6483803c96a44fd726d7358b9888ae5bb394ec"},
+    {file = "pyzmq-26.2.0-cp39-cp39-win_arm64.whl", hash = "sha256:7445be39143a8aa4faec43b076e06944b8f9d0701b669df4af200531b21e40bb"},
+    {file = "pyzmq-26.2.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:706e794564bec25819d21a41c31d4df2d48e1cc4b061e8d345d7fb4dd3e94072"},
+    {file = "pyzmq-26.2.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b435f2753621cd36e7c1762156815e21c985c72b19135dac43a7f4f31d28dd1"},
+    {file = "pyzmq-26.2.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:160c7e0a5eb178011e72892f99f918c04a131f36056d10d9c1afb223fc952c2d"},
+    {file = "pyzmq-26.2.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c4a71d5d6e7b28a47a394c0471b7e77a0661e2d651e7ae91e0cab0a587859ca"},
+    {file = "pyzmq-26.2.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:90412f2db8c02a3864cbfc67db0e3dcdbda336acf1c469526d3e869394fe001c"},
+    {file = "pyzmq-26.2.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2ea4ad4e6a12e454de05f2949d4beddb52460f3de7c8b9d5c46fbb7d7222e02c"},
+    {file = "pyzmq-26.2.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fc4f7a173a5609631bb0c42c23d12c49df3966f89f496a51d3eb0ec81f4519d6"},
+    {file = "pyzmq-26.2.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:878206a45202247781472a2d99df12a176fef806ca175799e1c6ad263510d57c"},
+    {file = "pyzmq-26.2.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:17c412bad2eb9468e876f556eb4ee910e62d721d2c7a53c7fa31e643d35352e6"},
+    {file = "pyzmq-26.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:0d987a3ae5a71c6226b203cfd298720e0086c7fe7c74f35fa8edddfbd6597eed"},
+    {file = "pyzmq-26.2.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:39887ac397ff35b7b775db7201095fc6310a35fdbae85bac4523f7eb3b840e20"},
+    {file = "pyzmq-26.2.0-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fdb5b3e311d4d4b0eb8b3e8b4d1b0a512713ad7e6a68791d0923d1aec433d919"},
+    {file = "pyzmq-26.2.0-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:226af7dcb51fdb0109f0016449b357e182ea0ceb6b47dfb5999d569e5db161d5"},
+    {file = "pyzmq-26.2.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bed0e799e6120b9c32756203fb9dfe8ca2fb8467fed830c34c877e25638c3fc"},
+    {file = "pyzmq-26.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:29c7947c594e105cb9e6c466bace8532dc1ca02d498684128b339799f5248277"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:cdeabcff45d1c219636ee2e54d852262e5c2e085d6cb476d938aee8d921356b3"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35cffef589bcdc587d06f9149f8d5e9e8859920a071df5a2671de2213bef592a"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18c8dc3b7468d8b4bdf60ce9d7141897da103c7a4690157b32b60acb45e333e6"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7133d0a1677aec369d67dd78520d3fa96dd7f3dcec99d66c1762870e5ea1a50a"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:6a96179a24b14fa6428cbfc08641c779a53f8fcec43644030328f44034c7f1f4"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4f78c88905461a9203eac9faac157a2a0dbba84a0fd09fd29315db27be40af9f"},
+    {file = "pyzmq-26.2.0.tar.gz", hash = "sha256:070672c258581c8e4f640b5159297580a9974b026043bd4ab0470be9ed324f1f"},
 ]
 
 [package.dependencies]
@@ -2041,101 +2324,116 @@ files = [
 
 [[package]]
 name = "regex"
-version = "2024.5.15"
+version = "2024.9.11"
 description = "Alternative regular expression module, to replace re."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "regex-2024.5.15-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a81e3cfbae20378d75185171587cbf756015ccb14840702944f014e0d93ea09f"},
-    {file = "regex-2024.5.15-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7b59138b219ffa8979013be7bc85bb60c6f7b7575df3d56dc1e403a438c7a3f6"},
-    {file = "regex-2024.5.15-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a0bd000c6e266927cb7a1bc39d55be95c4b4f65c5be53e659537537e019232b1"},
-    {file = "regex-2024.5.15-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5eaa7ddaf517aa095fa8da0b5015c44d03da83f5bd49c87961e3c997daed0de7"},
-    {file = "regex-2024.5.15-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ba68168daedb2c0bab7fd7e00ced5ba90aebf91024dea3c88ad5063c2a562cca"},
-    {file = "regex-2024.5.15-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6e8d717bca3a6e2064fc3a08df5cbe366369f4b052dcd21b7416e6d71620dca1"},
-    {file = "regex-2024.5.15-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1337b7dbef9b2f71121cdbf1e97e40de33ff114801263b275aafd75303bd62b5"},
-    {file = "regex-2024.5.15-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f9ebd0a36102fcad2f03696e8af4ae682793a5d30b46c647eaf280d6cfb32796"},
-    {file = "regex-2024.5.15-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9efa1a32ad3a3ea112224897cdaeb6aa00381627f567179c0314f7b65d354c62"},
-    {file = "regex-2024.5.15-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1595f2d10dff3d805e054ebdc41c124753631b6a471b976963c7b28543cf13b0"},
-    {file = "regex-2024.5.15-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b802512f3e1f480f41ab5f2cfc0e2f761f08a1f41092d6718868082fc0d27143"},
-    {file = "regex-2024.5.15-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:a0981022dccabca811e8171f913de05720590c915b033b7e601f35ce4ea7019f"},
-    {file = "regex-2024.5.15-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:19068a6a79cf99a19ccefa44610491e9ca02c2be3305c7760d3831d38a467a6f"},
-    {file = "regex-2024.5.15-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1b5269484f6126eee5e687785e83c6b60aad7663dafe842b34691157e5083e53"},
-    {file = "regex-2024.5.15-cp310-cp310-win32.whl", hash = "sha256:ada150c5adfa8fbcbf321c30c751dc67d2f12f15bd183ffe4ec7cde351d945b3"},
-    {file = "regex-2024.5.15-cp310-cp310-win_amd64.whl", hash = "sha256:ac394ff680fc46b97487941f5e6ae49a9f30ea41c6c6804832063f14b2a5a145"},
-    {file = "regex-2024.5.15-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f5b1dff3ad008dccf18e652283f5e5339d70bf8ba7c98bf848ac33db10f7bc7a"},
-    {file = "regex-2024.5.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c6a2b494a76983df8e3d3feea9b9ffdd558b247e60b92f877f93a1ff43d26656"},
-    {file = "regex-2024.5.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a32b96f15c8ab2e7d27655969a23895eb799de3665fa94349f3b2fbfd547236f"},
-    {file = "regex-2024.5.15-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:10002e86e6068d9e1c91eae8295ef690f02f913c57db120b58fdd35a6bb1af35"},
-    {file = "regex-2024.5.15-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ec54d5afa89c19c6dd8541a133be51ee1017a38b412b1321ccb8d6ddbeb4cf7d"},
-    {file = "regex-2024.5.15-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:10e4ce0dca9ae7a66e6089bb29355d4432caed736acae36fef0fdd7879f0b0cb"},
-    {file = "regex-2024.5.15-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e507ff1e74373c4d3038195fdd2af30d297b4f0950eeda6f515ae3d84a1770f"},
-    {file = "regex-2024.5.15-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d1f059a4d795e646e1c37665b9d06062c62d0e8cc3c511fe01315973a6542e40"},
-    {file = "regex-2024.5.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0721931ad5fe0dda45d07f9820b90b2148ccdd8e45bb9e9b42a146cb4f695649"},
-    {file = "regex-2024.5.15-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:833616ddc75ad595dee848ad984d067f2f31be645d603e4d158bba656bbf516c"},
-    {file = "regex-2024.5.15-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:287eb7f54fc81546346207c533ad3c2c51a8d61075127d7f6d79aaf96cdee890"},
-    {file = "regex-2024.5.15-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:19dfb1c504781a136a80ecd1fff9f16dddf5bb43cec6871778c8a907a085bb3d"},
-    {file = "regex-2024.5.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:119af6e56dce35e8dfb5222573b50c89e5508d94d55713c75126b753f834de68"},
-    {file = "regex-2024.5.15-cp311-cp311-win32.whl", hash = "sha256:1c1c174d6ec38d6c8a7504087358ce9213d4332f6293a94fbf5249992ba54efa"},
-    {file = "regex-2024.5.15-cp311-cp311-win_amd64.whl", hash = "sha256:9e717956dcfd656f5055cc70996ee2cc82ac5149517fc8e1b60261b907740201"},
-    {file = "regex-2024.5.15-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:632b01153e5248c134007209b5c6348a544ce96c46005d8456de1d552455b014"},
-    {file = "regex-2024.5.15-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e64198f6b856d48192bf921421fdd8ad8eb35e179086e99e99f711957ffedd6e"},
-    {file = "regex-2024.5.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:68811ab14087b2f6e0fc0c2bae9ad689ea3584cad6917fc57be6a48bbd012c49"},
-    {file = "regex-2024.5.15-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8ec0c2fea1e886a19c3bee0cd19d862b3aa75dcdfb42ebe8ed30708df64687a"},
-    {file = "regex-2024.5.15-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d0c0c0003c10f54a591d220997dd27d953cd9ccc1a7294b40a4be5312be8797b"},
-    {file = "regex-2024.5.15-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2431b9e263af1953c55abbd3e2efca67ca80a3de8a0437cb58e2421f8184717a"},
-    {file = "regex-2024.5.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a605586358893b483976cffc1723fb0f83e526e8f14c6e6614e75919d9862cf"},
-    {file = "regex-2024.5.15-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:391d7f7f1e409d192dba8bcd42d3e4cf9e598f3979cdaed6ab11288da88cb9f2"},
-    {file = "regex-2024.5.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9ff11639a8d98969c863d4617595eb5425fd12f7c5ef6621a4b74b71ed8726d5"},
-    {file = "regex-2024.5.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4eee78a04e6c67e8391edd4dad3279828dd66ac4b79570ec998e2155d2e59fd5"},
-    {file = "regex-2024.5.15-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8fe45aa3f4aa57faabbc9cb46a93363edd6197cbc43523daea044e9ff2fea83e"},
-    {file = "regex-2024.5.15-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:d0a3d8d6acf0c78a1fff0e210d224b821081330b8524e3e2bc5a68ef6ab5803d"},
-    {file = "regex-2024.5.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c486b4106066d502495b3025a0a7251bf37ea9540433940a23419461ab9f2a80"},
-    {file = "regex-2024.5.15-cp312-cp312-win32.whl", hash = "sha256:c49e15eac7c149f3670b3e27f1f28a2c1ddeccd3a2812cba953e01be2ab9b5fe"},
-    {file = "regex-2024.5.15-cp312-cp312-win_amd64.whl", hash = "sha256:673b5a6da4557b975c6c90198588181029c60793835ce02f497ea817ff647cb2"},
-    {file = "regex-2024.5.15-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:87e2a9c29e672fc65523fb47a90d429b70ef72b901b4e4b1bd42387caf0d6835"},
-    {file = "regex-2024.5.15-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c3bea0ba8b73b71b37ac833a7f3fd53825924165da6a924aec78c13032f20850"},
-    {file = "regex-2024.5.15-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:bfc4f82cabe54f1e7f206fd3d30fda143f84a63fe7d64a81558d6e5f2e5aaba9"},
-    {file = "regex-2024.5.15-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5bb9425fe881d578aeca0b2b4b3d314ec88738706f66f219c194d67179337cb"},
-    {file = "regex-2024.5.15-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64c65783e96e563103d641760664125e91bd85d8e49566ee560ded4da0d3e704"},
-    {file = "regex-2024.5.15-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cf2430df4148b08fb4324b848672514b1385ae3807651f3567871f130a728cc3"},
-    {file = "regex-2024.5.15-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5397de3219a8b08ae9540c48f602996aa6b0b65d5a61683e233af8605c42b0f2"},
-    {file = "regex-2024.5.15-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:455705d34b4154a80ead722f4f185b04c4237e8e8e33f265cd0798d0e44825fa"},
-    {file = "regex-2024.5.15-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b2b6f1b3bb6f640c1a92be3bbfbcb18657b125b99ecf141fb3310b5282c7d4ed"},
-    {file = "regex-2024.5.15-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:3ad070b823ca5890cab606c940522d05d3d22395d432f4aaaf9d5b1653e47ced"},
-    {file = "regex-2024.5.15-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:5b5467acbfc153847d5adb21e21e29847bcb5870e65c94c9206d20eb4e99a384"},
-    {file = "regex-2024.5.15-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:e6662686aeb633ad65be2a42b4cb00178b3fbf7b91878f9446075c404ada552f"},
-    {file = "regex-2024.5.15-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:2b4c884767504c0e2401babe8b5b7aea9148680d2e157fa28f01529d1f7fcf67"},
-    {file = "regex-2024.5.15-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:3cd7874d57f13bf70078f1ff02b8b0aa48d5b9ed25fc48547516c6aba36f5741"},
-    {file = "regex-2024.5.15-cp38-cp38-win32.whl", hash = "sha256:e4682f5ba31f475d58884045c1a97a860a007d44938c4c0895f41d64481edbc9"},
-    {file = "regex-2024.5.15-cp38-cp38-win_amd64.whl", hash = "sha256:d99ceffa25ac45d150e30bd9ed14ec6039f2aad0ffa6bb87a5936f5782fc1569"},
-    {file = "regex-2024.5.15-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:13cdaf31bed30a1e1c2453ef6015aa0983e1366fad2667657dbcac7b02f67133"},
-    {file = "regex-2024.5.15-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cac27dcaa821ca271855a32188aa61d12decb6fe45ffe3e722401fe61e323cd1"},
-    {file = "regex-2024.5.15-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7dbe2467273b875ea2de38ded4eba86cbcbc9a1a6d0aa11dcf7bd2e67859c435"},
-    {file = "regex-2024.5.15-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64f18a9a3513a99c4bef0e3efd4c4a5b11228b48aa80743be822b71e132ae4f5"},
-    {file = "regex-2024.5.15-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d347a741ea871c2e278fde6c48f85136c96b8659b632fb57a7d1ce1872547600"},
-    {file = "regex-2024.5.15-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1878b8301ed011704aea4c806a3cadbd76f84dece1ec09cc9e4dc934cfa5d4da"},
-    {file = "regex-2024.5.15-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4babf07ad476aaf7830d77000874d7611704a7fcf68c9c2ad151f5d94ae4bfc4"},
-    {file = "regex-2024.5.15-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35cb514e137cb3488bce23352af3e12fb0dbedd1ee6e60da053c69fb1b29cc6c"},
-    {file = "regex-2024.5.15-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cdd09d47c0b2efee9378679f8510ee6955d329424c659ab3c5e3a6edea696294"},
-    {file = "regex-2024.5.15-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:72d7a99cd6b8f958e85fc6ca5b37c4303294954eac1376535b03c2a43eb72629"},
-    {file = "regex-2024.5.15-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:a094801d379ab20c2135529948cb84d417a2169b9bdceda2a36f5f10977ebc16"},
-    {file = "regex-2024.5.15-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:c0c18345010870e58238790a6779a1219b4d97bd2e77e1140e8ee5d14df071aa"},
-    {file = "regex-2024.5.15-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:16093f563098448ff6b1fa68170e4acbef94e6b6a4e25e10eae8598bb1694b5d"},
-    {file = "regex-2024.5.15-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:e38a7d4e8f633a33b4c7350fbd8bad3b70bf81439ac67ac38916c4a86b465456"},
-    {file = "regex-2024.5.15-cp39-cp39-win32.whl", hash = "sha256:71a455a3c584a88f654b64feccc1e25876066c4f5ef26cd6dd711308aa538694"},
-    {file = "regex-2024.5.15-cp39-cp39-win_amd64.whl", hash = "sha256:cab12877a9bdafde5500206d1020a584355a97884dfd388af3699e9137bf7388"},
-    {file = "regex-2024.5.15.tar.gz", hash = "sha256:d3ee02d9e5f482cc8309134a91eeaacbdd2261ba111b0fef3748eeb4913e6a2c"},
+    {file = "regex-2024.9.11-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1494fa8725c285a81d01dc8c06b55287a1ee5e0e382d8413adc0a9197aac6408"},
+    {file = "regex-2024.9.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0e12c481ad92d129c78f13a2a3662317e46ee7ef96c94fd332e1c29131875b7d"},
+    {file = "regex-2024.9.11-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:16e13a7929791ac1216afde26f712802e3df7bf0360b32e4914dca3ab8baeea5"},
+    {file = "regex-2024.9.11-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46989629904bad940bbec2106528140a218b4a36bb3042d8406980be1941429c"},
+    {file = "regex-2024.9.11-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a906ed5e47a0ce5f04b2c981af1c9acf9e8696066900bf03b9d7879a6f679fc8"},
+    {file = "regex-2024.9.11-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9a091b0550b3b0207784a7d6d0f1a00d1d1c8a11699c1a4d93db3fbefc3ad35"},
+    {file = "regex-2024.9.11-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ddcd9a179c0a6fa8add279a4444015acddcd7f232a49071ae57fa6e278f1f71"},
+    {file = "regex-2024.9.11-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6b41e1adc61fa347662b09398e31ad446afadff932a24807d3ceb955ed865cc8"},
+    {file = "regex-2024.9.11-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ced479f601cd2f8ca1fd7b23925a7e0ad512a56d6e9476f79b8f381d9d37090a"},
+    {file = "regex-2024.9.11-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:635a1d96665f84b292e401c3d62775851aedc31d4f8784117b3c68c4fcd4118d"},
+    {file = "regex-2024.9.11-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c0256beda696edcf7d97ef16b2a33a8e5a875affd6fa6567b54f7c577b30a137"},
+    {file = "regex-2024.9.11-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:3ce4f1185db3fbde8ed8aa223fc9620f276c58de8b0d4f8cc86fd1360829edb6"},
+    {file = "regex-2024.9.11-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:09d77559e80dcc9d24570da3745ab859a9cf91953062e4ab126ba9d5993688ca"},
+    {file = "regex-2024.9.11-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7a22ccefd4db3f12b526eccb129390942fe874a3a9fdbdd24cf55773a1faab1a"},
+    {file = "regex-2024.9.11-cp310-cp310-win32.whl", hash = "sha256:f745ec09bc1b0bd15cfc73df6fa4f726dcc26bb16c23a03f9e3367d357eeedd0"},
+    {file = "regex-2024.9.11-cp310-cp310-win_amd64.whl", hash = "sha256:01c2acb51f8a7d6494c8c5eafe3d8e06d76563d8a8a4643b37e9b2dd8a2ff623"},
+    {file = "regex-2024.9.11-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2cce2449e5927a0bf084d346da6cd5eb016b2beca10d0013ab50e3c226ffc0df"},
+    {file = "regex-2024.9.11-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b37fa423beefa44919e009745ccbf353d8c981516e807995b2bd11c2c77d268"},
+    {file = "regex-2024.9.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:64ce2799bd75039b480cc0360907c4fb2f50022f030bf9e7a8705b636e408fad"},
+    {file = "regex-2024.9.11-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4cc92bb6db56ab0c1cbd17294e14f5e9224f0cc6521167ef388332604e92679"},
+    {file = "regex-2024.9.11-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d05ac6fa06959c4172eccd99a222e1fbf17b5670c4d596cb1e5cde99600674c4"},
+    {file = "regex-2024.9.11-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040562757795eeea356394a7fb13076ad4f99d3c62ab0f8bdfb21f99a1f85664"},
+    {file = "regex-2024.9.11-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6113c008a7780792efc80f9dfe10ba0cd043cbf8dc9a76ef757850f51b4edc50"},
+    {file = "regex-2024.9.11-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8e5fb5f77c8745a60105403a774fe2c1759b71d3e7b4ca237a5e67ad066c7199"},
+    {file = "regex-2024.9.11-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:54d9ff35d4515debf14bc27f1e3b38bfc453eff3220f5bce159642fa762fe5d4"},
+    {file = "regex-2024.9.11-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df5cbb1fbc74a8305b6065d4ade43b993be03dbe0f8b30032cced0d7740994bd"},
+    {file = "regex-2024.9.11-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7fb89ee5d106e4a7a51bce305ac4efb981536301895f7bdcf93ec92ae0d91c7f"},
+    {file = "regex-2024.9.11-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:a738b937d512b30bf75995c0159c0ddf9eec0775c9d72ac0202076c72f24aa96"},
+    {file = "regex-2024.9.11-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e28f9faeb14b6f23ac55bfbbfd3643f5c7c18ede093977f1df249f73fd22c7b1"},
+    {file = "regex-2024.9.11-cp311-cp311-win32.whl", hash = "sha256:18e707ce6c92d7282dfce370cd205098384b8ee21544e7cb29b8aab955b66fa9"},
+    {file = "regex-2024.9.11-cp311-cp311-win_amd64.whl", hash = "sha256:313ea15e5ff2a8cbbad96ccef6be638393041b0a7863183c2d31e0c6116688cf"},
+    {file = "regex-2024.9.11-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:b0d0a6c64fcc4ef9c69bd5b3b3626cc3776520a1637d8abaa62b9edc147a58f7"},
+    {file = "regex-2024.9.11-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:49b0e06786ea663f933f3710a51e9385ce0cba0ea56b67107fd841a55d56a231"},
+    {file = "regex-2024.9.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5b513b6997a0b2f10e4fd3a1313568e373926e8c252bd76c960f96fd039cd28d"},
+    {file = "regex-2024.9.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee439691d8c23e76f9802c42a95cfeebf9d47cf4ffd06f18489122dbb0a7ad64"},
+    {file = "regex-2024.9.11-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a8f877c89719d759e52783f7fe6e1c67121076b87b40542966c02de5503ace42"},
+    {file = "regex-2024.9.11-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:23b30c62d0f16827f2ae9f2bb87619bc4fba2044911e2e6c2eb1af0161cdb766"},
+    {file = "regex-2024.9.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85ab7824093d8f10d44330fe1e6493f756f252d145323dd17ab6b48733ff6c0a"},
+    {file = "regex-2024.9.11-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8dee5b4810a89447151999428fe096977346cf2f29f4d5e29609d2e19e0199c9"},
+    {file = "regex-2024.9.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98eeee2f2e63edae2181c886d7911ce502e1292794f4c5ee71e60e23e8d26b5d"},
+    {file = "regex-2024.9.11-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:57fdd2e0b2694ce6fc2e5ccf189789c3e2962916fb38779d3e3521ff8fe7a822"},
+    {file = "regex-2024.9.11-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d552c78411f60b1fdaafd117a1fca2f02e562e309223b9d44b7de8be451ec5e0"},
+    {file = "regex-2024.9.11-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:a0b2b80321c2ed3fcf0385ec9e51a12253c50f146fddb2abbb10f033fe3d049a"},
+    {file = "regex-2024.9.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:18406efb2f5a0e57e3a5881cd9354c1512d3bb4f5c45d96d110a66114d84d23a"},
+    {file = "regex-2024.9.11-cp312-cp312-win32.whl", hash = "sha256:e464b467f1588e2c42d26814231edecbcfe77f5ac414d92cbf4e7b55b2c2a776"},
+    {file = "regex-2024.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:9e8719792ca63c6b8340380352c24dcb8cd7ec49dae36e963742a275dfae6009"},
+    {file = "regex-2024.9.11-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c157bb447303070f256e084668b702073db99bbb61d44f85d811025fcf38f784"},
+    {file = "regex-2024.9.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4db21ece84dfeefc5d8a3863f101995de646c6cb0536952c321a2650aa202c36"},
+    {file = "regex-2024.9.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:220e92a30b426daf23bb67a7962900ed4613589bab80382be09b48896d211e92"},
+    {file = "regex-2024.9.11-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb1ae19e64c14c7ec1995f40bd932448713d3c73509e82d8cd7744dc00e29e86"},
+    {file = "regex-2024.9.11-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f47cd43a5bfa48f86925fe26fbdd0a488ff15b62468abb5d2a1e092a4fb10e85"},
+    {file = "regex-2024.9.11-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9d4a76b96f398697fe01117093613166e6aa8195d63f1b4ec3f21ab637632963"},
+    {file = "regex-2024.9.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ea51dcc0835eea2ea31d66456210a4e01a076d820e9039b04ae8d17ac11dee6"},
+    {file = "regex-2024.9.11-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7aaa315101c6567a9a45d2839322c51c8d6e81f67683d529512f5bcfb99c802"},
+    {file = "regex-2024.9.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c57d08ad67aba97af57a7263c2d9006d5c404d721c5f7542f077f109ec2a4a29"},
+    {file = "regex-2024.9.11-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f8404bf61298bb6f8224bb9176c1424548ee1181130818fcd2cbffddc768bed8"},
+    {file = "regex-2024.9.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dd4490a33eb909ef5078ab20f5f000087afa2a4daa27b4c072ccb3cb3050ad84"},
+    {file = "regex-2024.9.11-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:eee9130eaad130649fd73e5cd92f60e55708952260ede70da64de420cdcad554"},
+    {file = "regex-2024.9.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6a2644a93da36c784e546de579ec1806bfd2763ef47babc1b03d765fe560c9f8"},
+    {file = "regex-2024.9.11-cp313-cp313-win32.whl", hash = "sha256:e997fd30430c57138adc06bba4c7c2968fb13d101e57dd5bb9355bf8ce3fa7e8"},
+    {file = "regex-2024.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:042c55879cfeb21a8adacc84ea347721d3d83a159da6acdf1116859e2427c43f"},
+    {file = "regex-2024.9.11-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:35f4a6f96aa6cb3f2f7247027b07b15a374f0d5b912c0001418d1d55024d5cb4"},
+    {file = "regex-2024.9.11-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:55b96e7ce3a69a8449a66984c268062fbaa0d8ae437b285428e12797baefce7e"},
+    {file = "regex-2024.9.11-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cb130fccd1a37ed894824b8c046321540263013da72745d755f2d35114b81a60"},
+    {file = "regex-2024.9.11-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:323c1f04be6b2968944d730e5c2091c8c89767903ecaa135203eec4565ed2b2b"},
+    {file = "regex-2024.9.11-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be1c8ed48c4c4065ecb19d882a0ce1afe0745dfad8ce48c49586b90a55f02366"},
+    {file = "regex-2024.9.11-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5b029322e6e7b94fff16cd120ab35a253236a5f99a79fb04fda7ae71ca20ae8"},
+    {file = "regex-2024.9.11-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6fff13ef6b5f29221d6904aa816c34701462956aa72a77f1f151a8ec4f56aeb"},
+    {file = "regex-2024.9.11-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:587d4af3979376652010e400accc30404e6c16b7df574048ab1f581af82065e4"},
+    {file = "regex-2024.9.11-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:079400a8269544b955ffa9e31f186f01d96829110a3bf79dc338e9910f794fca"},
+    {file = "regex-2024.9.11-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:f9268774428ec173654985ce55fc6caf4c6d11ade0f6f914d48ef4719eb05ebb"},
+    {file = "regex-2024.9.11-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:23f9985c8784e544d53fc2930fc1ac1a7319f5d5332d228437acc9f418f2f168"},
+    {file = "regex-2024.9.11-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:ae2941333154baff9838e88aa71c1d84f4438189ecc6021a12c7573728b5838e"},
+    {file = "regex-2024.9.11-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:e93f1c331ca8e86fe877a48ad64e77882c0c4da0097f2212873a69bbfea95d0c"},
+    {file = "regex-2024.9.11-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:846bc79ee753acf93aef4184c040d709940c9d001029ceb7b7a52747b80ed2dd"},
+    {file = "regex-2024.9.11-cp38-cp38-win32.whl", hash = "sha256:c94bb0a9f1db10a1d16c00880bdebd5f9faf267273b8f5bd1878126e0fbde771"},
+    {file = "regex-2024.9.11-cp38-cp38-win_amd64.whl", hash = "sha256:2b08fce89fbd45664d3df6ad93e554b6c16933ffa9d55cb7e01182baaf971508"},
+    {file = "regex-2024.9.11-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:07f45f287469039ffc2c53caf6803cd506eb5f5f637f1d4acb37a738f71dd066"},
+    {file = "regex-2024.9.11-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4838e24ee015101d9f901988001038f7f0d90dc0c3b115541a1365fb439add62"},
+    {file = "regex-2024.9.11-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6edd623bae6a737f10ce853ea076f56f507fd7726bee96a41ee3d68d347e4d16"},
+    {file = "regex-2024.9.11-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c69ada171c2d0e97a4b5aa78fbb835e0ffbb6b13fc5da968c09811346564f0d3"},
+    {file = "regex-2024.9.11-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:02087ea0a03b4af1ed6ebab2c54d7118127fee8d71b26398e8e4b05b78963199"},
+    {file = "regex-2024.9.11-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69dee6a020693d12a3cf892aba4808fe168d2a4cef368eb9bf74f5398bfd4ee8"},
+    {file = "regex-2024.9.11-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:297f54910247508e6e5cae669f2bc308985c60540a4edd1c77203ef19bfa63ca"},
+    {file = "regex-2024.9.11-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecea58b43a67b1b79805f1a0255730edaf5191ecef84dbc4cc85eb30bc8b63b9"},
+    {file = "regex-2024.9.11-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:eab4bb380f15e189d1313195b062a6aa908f5bd687a0ceccd47c8211e9cf0d4a"},
+    {file = "regex-2024.9.11-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0cbff728659ce4bbf4c30b2a1be040faafaa9eca6ecde40aaff86f7889f4ab39"},
+    {file = "regex-2024.9.11-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:54c4a097b8bc5bb0dfc83ae498061d53ad7b5762e00f4adaa23bee22b012e6ba"},
+    {file = "regex-2024.9.11-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:73d6d2f64f4d894c96626a75578b0bf7d9e56dcda8c3d037a2118fdfe9b1c664"},
+    {file = "regex-2024.9.11-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:e53b5fbab5d675aec9f0c501274c467c0f9a5d23696cfc94247e1fb56501ed89"},
+    {file = "regex-2024.9.11-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0ffbcf9221e04502fc35e54d1ce9567541979c3fdfb93d2c554f0ca583a19b35"},
+    {file = "regex-2024.9.11-cp39-cp39-win32.whl", hash = "sha256:e4c22e1ac1f1ec1e09f72e6c44d8f2244173db7eb9629cc3a346a8d7ccc31142"},
+    {file = "regex-2024.9.11-cp39-cp39-win_amd64.whl", hash = "sha256:faa3c142464efec496967359ca99696c896c591c56c53506bac1ad465f66e919"},
+    {file = "regex-2024.9.11.tar.gz", hash = "sha256:6c188c307e8433bcb63dc1915022deb553b4203a70722fc542c363bf120a01fd"},
 ]
 
 [[package]]
 name = "requests"
-version = "2.32.2"
+version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "requests-2.32.2-py3-none-any.whl", hash = "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c"},
-    {file = "requests-2.32.2.tar.gz", hash = "sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289"},
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
 
 [package.dependencies]
@@ -2241,6 +2539,17 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.6"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"},
+    {file = "soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb"},
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -2283,33 +2592,33 @@ files = [
 
 [[package]]
 name = "tomlkit"
-version = "0.12.5"
+version = "0.13.2"
 description = "Style preserving TOML library"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "tomlkit-0.12.5-py3-none-any.whl", hash = "sha256:af914f5a9c59ed9d0762c7b64d3b5d5df007448eb9cd2edc8a46b1eafead172f"},
-    {file = "tomlkit-0.12.5.tar.gz", hash = "sha256:eef34fba39834d4d6b73c9ba7f3e4d1c417a4e56f89a7e96e090dd0d24b8fb3c"},
+    {file = "tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde"},
+    {file = "tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79"},
 ]
 
 [[package]]
 name = "tornado"
-version = "6.4"
+version = "6.4.1"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 optional = false
-python-versions = ">= 3.8"
+python-versions = ">=3.8"
 files = [
-    {file = "tornado-6.4-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:02ccefc7d8211e5a7f9e8bc3f9e5b0ad6262ba2fbb683a6443ecc804e5224ce0"},
-    {file = "tornado-6.4-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:27787de946a9cffd63ce5814c33f734c627a87072ec7eed71f7fc4417bb16263"},
-    {file = "tornado-6.4-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7894c581ecdcf91666a0912f18ce5e757213999e183ebfc2c3fdbf4d5bd764e"},
-    {file = "tornado-6.4-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e43bc2e5370a6a8e413e1e1cd0c91bedc5bd62a74a532371042a18ef19e10579"},
-    {file = "tornado-6.4-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0251554cdd50b4b44362f73ad5ba7126fc5b2c2895cc62b14a1c2d7ea32f212"},
-    {file = "tornado-6.4-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:fd03192e287fbd0899dd8f81c6fb9cbbc69194d2074b38f384cb6fa72b80e9c2"},
-    {file = "tornado-6.4-cp38-abi3-musllinux_1_1_i686.whl", hash = "sha256:88b84956273fbd73420e6d4b8d5ccbe913c65d31351b4c004ae362eba06e1f78"},
-    {file = "tornado-6.4-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:71ddfc23a0e03ef2df1c1397d859868d158c8276a0603b96cf86892bff58149f"},
-    {file = "tornado-6.4-cp38-abi3-win32.whl", hash = "sha256:6f8a6c77900f5ae93d8b4ae1196472d0ccc2775cc1dfdc9e7727889145c45052"},
-    {file = "tornado-6.4-cp38-abi3-win_amd64.whl", hash = "sha256:10aeaa8006333433da48dec9fe417877f8bcc21f48dda8d661ae79da357b2a63"},
-    {file = "tornado-6.4.tar.gz", hash = "sha256:72291fa6e6bc84e626589f1c29d90a5a6d593ef5ae68052ee2ef000dfd273dee"},
+    {file = "tornado-6.4.1-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:163b0aafc8e23d8cdc3c9dfb24c5368af84a81e3364745ccb4427669bf84aec8"},
+    {file = "tornado-6.4.1-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6d5ce3437e18a2b66fbadb183c1d3364fb03f2be71299e7d10dbeeb69f4b2a14"},
+    {file = "tornado-6.4.1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2e20b9113cd7293f164dc46fffb13535266e713cdb87bd2d15ddb336e96cfc4"},
+    {file = "tornado-6.4.1-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ae50a504a740365267b2a8d1a90c9fbc86b780a39170feca9bcc1787ff80842"},
+    {file = "tornado-6.4.1-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613bf4ddf5c7a95509218b149b555621497a6cc0d46ac341b30bd9ec19eac7f3"},
+    {file = "tornado-6.4.1-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:25486eb223babe3eed4b8aecbac33b37e3dd6d776bc730ca14e1bf93888b979f"},
+    {file = "tornado-6.4.1-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:454db8a7ecfcf2ff6042dde58404164d969b6f5d58b926da15e6b23817950fc4"},
+    {file = "tornado-6.4.1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a02a08cc7a9314b006f653ce40483b9b3c12cda222d6a46d4ac63bb6c9057698"},
+    {file = "tornado-6.4.1-cp38-abi3-win32.whl", hash = "sha256:d9a566c40b89757c9aa8e6f032bcdb8ca8795d7c1a9762910c722b1635c9de4d"},
+    {file = "tornado-6.4.1-cp38-abi3-win_amd64.whl", hash = "sha256:b24b8982ed444378d7f21d563f4180a2de31ced9d8d84443907a0a64da2072e7"},
+    {file = "tornado-6.4.1.tar.gz", hash = "sha256:92d3ab53183d8c50f8204a51e6f91d18a15d5ef261e84d452800d4ff6fc504e9"},
 ]
 
 [[package]]
@@ -2365,24 +2674,24 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.0"
+version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.12.0-py3-none-any.whl", hash = "sha256:b349c66bea9016ac22978d800cfff206d5f9816951f12a7d0ec5578b0a819594"},
-    {file = "typing_extensions-4.12.0.tar.gz", hash = "sha256:8cbcdc8606ebcb0d95453ad7dc5065e6237b6aa230a31e81d0f440c30fed5fd8"},
+    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
+    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]
 name = "urllib3"
-version = "1.26.18"
+version = "1.26.20"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
-    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
-    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
+    {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
+    {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
 ]
 
 [package.extras]
@@ -2406,13 +2715,13 @@ test = ["coverage", "flake8 (>=3.7)", "mypy", "pretend", "pytest"]
 
 [[package]]
 name = "virtualenv"
-version = "20.26.2"
+version = "20.26.4"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.26.2-py3-none-any.whl", hash = "sha256:a624db5e94f01ad993d476b9ee5346fdf7b9de43ccaee0e0197012dc838a0e9b"},
-    {file = "virtualenv-20.26.2.tar.gz", hash = "sha256:82bf0f4eebbb78d36ddaee0283d43fe5736b53880b8a8cdcd37390a07ac3741c"},
+    {file = "virtualenv-20.26.4-py3-none-any.whl", hash = "sha256:48f2695d9809277003f30776d155615ffc11328e6a0a8c1f0ec80188d7874a55"},
+    {file = "virtualenv-20.26.4.tar.gz", hash = "sha256:c17f4e0f3e6036e9f26700446f85c76ab11df65ff6d8a9cbfad9f71aabfcf23c"},
 ]
 
 [package.dependencies]
@@ -2426,43 +2735,41 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [[package]]
 name = "watchdog"
-version = "4.0.1"
+version = "5.0.2"
 description = "Filesystem events monitoring"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "watchdog-4.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:da2dfdaa8006eb6a71051795856bedd97e5b03e57da96f98e375682c48850645"},
-    {file = "watchdog-4.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e93f451f2dfa433d97765ca2634628b789b49ba8b504fdde5837cdcf25fdb53b"},
-    {file = "watchdog-4.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ef0107bbb6a55f5be727cfc2ef945d5676b97bffb8425650dadbb184be9f9a2b"},
-    {file = "watchdog-4.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:17e32f147d8bf9657e0922c0940bcde863b894cd871dbb694beb6704cfbd2fb5"},
-    {file = "watchdog-4.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:03e70d2df2258fb6cb0e95bbdbe06c16e608af94a3ffbd2b90c3f1e83eb10767"},
-    {file = "watchdog-4.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:123587af84260c991dc5f62a6e7ef3d1c57dfddc99faacee508c71d287248459"},
-    {file = "watchdog-4.0.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:093b23e6906a8b97051191a4a0c73a77ecc958121d42346274c6af6520dec175"},
-    {file = "watchdog-4.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:611be3904f9843f0529c35a3ff3fd617449463cb4b73b1633950b3d97fa4bfb7"},
-    {file = "watchdog-4.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:62c613ad689ddcb11707f030e722fa929f322ef7e4f18f5335d2b73c61a85c28"},
-    {file = "watchdog-4.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d4925e4bf7b9bddd1c3de13c9b8a2cdb89a468f640e66fbfabaf735bd85b3e35"},
-    {file = "watchdog-4.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cad0bbd66cd59fc474b4a4376bc5ac3fc698723510cbb64091c2a793b18654db"},
-    {file = "watchdog-4.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a3c2c317a8fb53e5b3d25790553796105501a235343f5d2bf23bb8649c2c8709"},
-    {file = "watchdog-4.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c9904904b6564d4ee8a1ed820db76185a3c96e05560c776c79a6ce5ab71888ba"},
-    {file = "watchdog-4.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:667f3c579e813fcbad1b784db7a1aaa96524bed53437e119f6a2f5de4db04235"},
-    {file = "watchdog-4.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d10a681c9a1d5a77e75c48a3b8e1a9f2ae2928eda463e8d33660437705659682"},
-    {file = "watchdog-4.0.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0144c0ea9997b92615af1d94afc0c217e07ce2c14912c7b1a5731776329fcfc7"},
-    {file = "watchdog-4.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:998d2be6976a0ee3a81fb8e2777900c28641fb5bfbd0c84717d89bca0addcdc5"},
-    {file = "watchdog-4.0.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:e7921319fe4430b11278d924ef66d4daa469fafb1da679a2e48c935fa27af193"},
-    {file = "watchdog-4.0.1-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:f0de0f284248ab40188f23380b03b59126d1479cd59940f2a34f8852db710625"},
-    {file = "watchdog-4.0.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:bca36be5707e81b9e6ce3208d92d95540d4ca244c006b61511753583c81c70dd"},
-    {file = "watchdog-4.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:ab998f567ebdf6b1da7dc1e5accfaa7c6992244629c0fdaef062f43249bd8dee"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:dddba7ca1c807045323b6af4ff80f5ddc4d654c8bce8317dde1bd96b128ed253"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_armv7l.whl", hash = "sha256:4513ec234c68b14d4161440e07f995f231be21a09329051e67a2118a7a612d2d"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_i686.whl", hash = "sha256:4107ac5ab936a63952dea2a46a734a23230aa2f6f9db1291bf171dac3ebd53c6"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_ppc64.whl", hash = "sha256:6e8c70d2cd745daec2a08734d9f63092b793ad97612470a0ee4cbb8f5f705c57"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:f27279d060e2ab24c0aa98363ff906d2386aa6c4dc2f1a374655d4e02a6c5e5e"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_s390x.whl", hash = "sha256:f8affdf3c0f0466e69f5b3917cdd042f89c8c63aebdb9f7c078996f607cdb0f5"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ac7041b385f04c047fcc2951dc001671dee1b7e0615cde772e84b01fbf68ee84"},
-    {file = "watchdog-4.0.1-py3-none-win32.whl", hash = "sha256:206afc3d964f9a233e6ad34618ec60b9837d0582b500b63687e34011e15bb429"},
-    {file = "watchdog-4.0.1-py3-none-win_amd64.whl", hash = "sha256:7577b3c43e5909623149f76b099ac49a1a01ca4e167d1785c76eb52fa585745a"},
-    {file = "watchdog-4.0.1-py3-none-win_ia64.whl", hash = "sha256:d7b9f5f3299e8dd230880b6c55504a1f69cf1e4316275d1b215ebdd8187ec88d"},
-    {file = "watchdog-4.0.1.tar.gz", hash = "sha256:eebaacf674fa25511e8867028d281e602ee6500045b57f43b08778082f7f8b44"},
+    {file = "watchdog-5.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d961f4123bb3c447d9fcdcb67e1530c366f10ab3a0c7d1c0c9943050936d4877"},
+    {file = "watchdog-5.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72990192cb63872c47d5e5fefe230a401b87fd59d257ee577d61c9e5564c62e5"},
+    {file = "watchdog-5.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6bec703ad90b35a848e05e1b40bf0050da7ca28ead7ac4be724ae5ac2653a1a0"},
+    {file = "watchdog-5.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dae7a1879918f6544201d33666909b040a46421054a50e0f773e0d870ed7438d"},
+    {file = "watchdog-5.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c4a440f725f3b99133de610bfec93d570b13826f89616377715b9cd60424db6e"},
+    {file = "watchdog-5.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f8b2918c19e0d48f5f20df458c84692e2a054f02d9df25e6c3c930063eca64c1"},
+    {file = "watchdog-5.0.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:aa9cd6e24126d4afb3752a3e70fce39f92d0e1a58a236ddf6ee823ff7dba28ee"},
+    {file = "watchdog-5.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f627c5bf5759fdd90195b0c0431f99cff4867d212a67b384442c51136a098ed7"},
+    {file = "watchdog-5.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d7594a6d32cda2b49df3fd9abf9b37c8d2f3eab5df45c24056b4a671ac661619"},
+    {file = "watchdog-5.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba32efcccfe2c58f4d01115440d1672b4eb26cdd6fc5b5818f1fb41f7c3e1889"},
+    {file = "watchdog-5.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:963f7c4c91e3f51c998eeff1b3fb24a52a8a34da4f956e470f4b068bb47b78ee"},
+    {file = "watchdog-5.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8c47150aa12f775e22efff1eee9f0f6beee542a7aa1a985c271b1997d340184f"},
+    {file = "watchdog-5.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:14dd4ed023d79d1f670aa659f449bcd2733c33a35c8ffd88689d9d243885198b"},
+    {file = "watchdog-5.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b84bff0391ad4abe25c2740c7aec0e3de316fdf7764007f41e248422a7760a7f"},
+    {file = "watchdog-5.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e8d5ff39f0a9968952cce548e8e08f849141a4fcc1290b1c17c032ba697b9d7"},
+    {file = "watchdog-5.0.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:fb223456db6e5f7bd9bbd5cd969f05aae82ae21acc00643b60d81c770abd402b"},
+    {file = "watchdog-5.0.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9814adb768c23727a27792c77812cf4e2fd9853cd280eafa2bcfa62a99e8bd6e"},
+    {file = "watchdog-5.0.2-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:901ee48c23f70193d1a7bc2d9ee297df66081dd5f46f0ca011be4f70dec80dab"},
+    {file = "watchdog-5.0.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:638bcca3d5b1885c6ec47be67bf712b00a9ab3d4b22ec0881f4889ad870bc7e8"},
+    {file = "watchdog-5.0.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:5597c051587f8757798216f2485e85eac583c3b343e9aa09127a3a6f82c65ee8"},
+    {file = "watchdog-5.0.2-py3-none-manylinux2014_armv7l.whl", hash = "sha256:53ed1bf71fcb8475dd0ef4912ab139c294c87b903724b6f4a8bd98e026862e6d"},
+    {file = "watchdog-5.0.2-py3-none-manylinux2014_i686.whl", hash = "sha256:29e4a2607bd407d9552c502d38b45a05ec26a8e40cc7e94db9bb48f861fa5abc"},
+    {file = "watchdog-5.0.2-py3-none-manylinux2014_ppc64.whl", hash = "sha256:b6dc8f1d770a8280997e4beae7b9a75a33b268c59e033e72c8a10990097e5fde"},
+    {file = "watchdog-5.0.2-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:d2ab34adc9bf1489452965cdb16a924e97d4452fcf88a50b21859068b50b5c3b"},
+    {file = "watchdog-5.0.2-py3-none-manylinux2014_s390x.whl", hash = "sha256:7d1aa7e4bb0f0c65a1a91ba37c10e19dabf7eaaa282c5787e51371f090748f4b"},
+    {file = "watchdog-5.0.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:726eef8f8c634ac6584f86c9c53353a010d9f311f6c15a034f3800a7a891d941"},
+    {file = "watchdog-5.0.2-py3-none-win32.whl", hash = "sha256:bda40c57115684d0216556671875e008279dea2dc00fcd3dde126ac8e0d7a2fb"},
+    {file = "watchdog-5.0.2-py3-none-win_amd64.whl", hash = "sha256:d010be060c996db725fbce7e3ef14687cdcc76f4ca0e4339a68cc4532c382a73"},
+    {file = "watchdog-5.0.2-py3-none-win_ia64.whl", hash = "sha256:3960136b2b619510569b90f0cd96408591d6c251a75c97690f4553ca88889769"},
+    {file = "watchdog-5.0.2.tar.gz", hash = "sha256:dcebf7e475001d2cdeb020be630dc5b687e9acdd60d16fea6bb4508e7b94cf76"},
 ]
 
 [package.extras]
@@ -2478,20 +2785,6 @@ files = [
     {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
 ]
-
-[[package]]
-name = "wheel"
-version = "0.43.0"
-description = "A built-package format for Python"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "wheel-0.43.0-py3-none-any.whl", hash = "sha256:55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81"},
-    {file = "wheel-0.43.0.tar.gz", hash = "sha256:465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85"},
-]
-
-[package.extras]
-test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 
 [[package]]
 name = "wrapt"
@@ -2574,20 +2867,24 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.19.0"
+version = "3.20.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.19.0-py3-none-any.whl", hash = "sha256:96dc6ad62f1441bcaccef23b274ec471518daf4fbbc580341204936a5a3dddec"},
-    {file = "zipp-3.19.0.tar.gz", hash = "sha256:952df858fb3164426c976d9338d3961e8e8b3758e2e059e0f754b8c4262625ee"},
+    {file = "zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350"},
+    {file = "zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
+type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8.9"
-content-hash = "e77264cbb5933c3e88412933e2736aa7fa131059d5f262139b456991a9e9a342"
+python-versions = "^3.9,<3.12"
+content-hash = "43bce5665b474f507c12c83fbdcabfe67baa6a4ce99dc793e3d3d8ff57d4d415"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [tool.poetry]
 name = "spark-expectations"
-version = "0.0.0"
+version = "0.0.1-pre.40+79b04d6"
 description = "This project helps us to run Data Quality Rules in flight while spark job is being run"
 authors = ["Ashok Singamaneni <ashok.singamaneni@nike.com>"]
 readme = "README.md"
 packages = [{ include = "spark_expectations" }]
 
 [tool.poetry.dependencies]
-python = "^3.8.9"
+python = "^3.9,<3.12"
 pluggy = ">=1"
-pyspark = "^3.0.0,<3.5"
+pyspark = "^3.0.0"
 requests = "^2.28.1"
 
 [tool.poetry.group.dev.dependencies]
@@ -18,6 +18,12 @@ pytest = "7.3.1"
 pytest-mock = "3.10.0"
 coverage = "7.2.5"
 pyspark = "^3.0.0"
+pandas = "1.5.3"
+numpy = "1.26.4"
+pyarrow = "7.0.0"
+grpcio = "1.48.1"
+google = "3.0.0"
+protobuf = "4.21.12"
 mypy = "1.3.0"
 mkdocs = "1.4.3"
 prospector = "1.10.0"
@@ -36,7 +42,7 @@ botocore = "1.29.133"                                      # This is just for fi
 ipykernel = "^6.29.2"
 
 [tool.poetry-dynamic-versioning]
-enable = true
+enable = false
 vcs = "git"
 bump = true
 style = "semver"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ botocore = "1.29.133"                                      # This is just for fi
 ipykernel = "^6.29.2"
 
 [tool.poetry-dynamic-versioning]
-enable = false
+enable = true
 vcs = "git"
 bump = true
 style = "semver"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spark-expectations"
-version = "0.0.1-pre.40+79b04d6"
+version = "0.0.0"
 description = "This project helps us to run Data Quality Rules in flight while spark job is being run"
 authors = ["Ashok Singamaneni <ashok.singamaneni@nike.com>"]
 readme = "README.md"

--- a/spark_expectations/core/__init__.py
+++ b/spark_expectations/core/__init__.py
@@ -13,7 +13,7 @@ def get_spark_session() -> SparkSession:
             SparkSession.builder.config(
                 "spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension"
             )
-            .config("spark.jars.packages", "io.delta:delta-core_2.12:2.4.0")
+            .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.0.0")
             .config(
                 "spark.sql.catalog.spark_catalog",
                 "org.apache.spark.sql.delta.catalog.DeltaCatalog",

--- a/spark_expectations/core/expectations.py
+++ b/spark_expectations/core/expectations.py
@@ -53,7 +53,7 @@ class SparkExpectations:
     def __post_init__(self) -> None:
         # Databricks runtime 14 and above could pass either instance of a Dataframe depending on how data was read
         if isinstance(self.rules_df, DataFrame) or isinstance(
-                self.rules_df, connect.dataframe.DataFrame
+            self.rules_df, connect.dataframe.DataFrame
         ):
             try:
                 self.spark: Optional[SparkSession] = self.rules_df.sparkSession
@@ -363,7 +363,7 @@ class SparkExpectations:
                     )
 
                     if isinstance(_df, DataFrame) or isinstance(
-                            _df, connect.dataframe.DataFrame
+                        _df, connect.dataframe.DataFrame
                     ):
                         _log.info("The function dataframe is created")
                         self._context.set_table_name(table_name)

--- a/spark_expectations/examples/base_setup.py
+++ b/spark_expectations/examples/base_setup.py
@@ -126,7 +126,7 @@ def set_up_delta() -> SparkSession:
         SparkSession.builder.config(
             "spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension"
         )
-        .config("spark.jars.packages", "io.delta:delta-core_2.12:2.4.0")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.0.0")
         .config(
             "spark.sql.catalog.spark_catalog",
             "org.apache.spark.sql.delta.catalog.DeltaCatalog",

--- a/tests/core/test_expectations.py
+++ b/tests/core/test_expectations.py
@@ -34,8 +34,8 @@ def fixture_setup_local_kafka_topic():
     current_dir = os.path.dirname(os.path.abspath(__file__))
 
     if (
-            os.getenv("UNIT_TESTING_ENV")
-            != "spark_expectations_unit_testing_on_github_actions"
+        os.getenv("UNIT_TESTING_ENV")
+        != "spark_expectations_unit_testing_on_github_actions"
     ):
         # remove if docker conatiner is running
         os.system(
@@ -214,7 +214,7 @@ def fixture_spark_expectations(_fixture_rules_df):
 def test_spark_session_initialization():
     # Test if spark session is initialized even if dataframe.sparkSession is not accessible
     with patch.object(
-            DataFrame, "sparkSession", new_callable=PropertyMock
+        DataFrame, "sparkSession", new_callable=PropertyMock
     ) as mock_sparkSession:
         mock_sparkSession.side_effect = AttributeError(
             "The 'sparkSession' attribute is not accessible"
@@ -235,7 +235,7 @@ def test_spark_session_initialization():
 
     # Test if exception is raised if sparkSession.getActiveSession() returns None
     with patch.object(
-            DataFrame, "sparkSession", new_callable=PropertyMock
+        DataFrame, "sparkSession", new_callable=PropertyMock
     ) as mock_sparkSession:
         mock_sparkSession.side_effect = AttributeError(
             "The 'sparkSession' attribute is not accessible"
@@ -257,8 +257,8 @@ def test_spark_session_initialization():
                 )
                 assert se.spark is None
                 assert (
-                        str(e.value)
-                        == "Spark session is not available, please initialize a spark session before calling SE"
+                    str(e.value)
+                    == "Spark session is not available, please initialize a spark session before calling SE"
                 )
 
 
@@ -279,2533 +279,2533 @@ def test_spark_session_initialization():
     "status",
     [
         (
-                # Note: where err: refers error table and fnl: final table
-                # test case 0
-                # In this test case, the action for failed rows is "ignore",
-                # so the function should return the input DataFrame with all rows.
-                # collect stats in the test_stats_table and
-                # log the error records into the error table.
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a"},
-                        # row doesn't meet expectations(ignore), log into err & fnl
-                        {"col1": 2, "col2": "b"},
-                        # row meets expectations(ignore), log into final table
-                        {"col1": 3, "col2": "c"},
-                        # row meets expectations(ignore), log into final table
-                    ]
-                ),
+            # Note: where err: refers error table and fnl: final table
+            # test case 0
+            # In this test case, the action for failed rows is "ignore",
+            # so the function should return the input DataFrame with all rows.
+            # collect stats in the test_stats_table and
+            # log the error records into the error table.
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "col1 > 1",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "col1 value must be greater than 1",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "10",
-                    }
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                # expected res
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a"},
-                        {"col1": 2, "col2": "b"},
-                        {"col1": 3, "col2": "c"},
-                    ]
-                ),
-                3,  # input count
-                1,  # error count
-                3,  # output count
-                None,  # source_agg_dq_res
-                None,  # final_agg_dq_res
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    {"col1": 1, "col2": "a"},
+                    # row doesn't meet expectations(ignore), log into err & fnl
+                    {"col1": 2, "col2": "b"},
+                    # row meets expectations(ignore), log into final table
+                    {"col1": 3, "col2": "c"},
+                    # row meets expectations(ignore), log into final table
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
-                },  # dq_rules
-                # status at different stages for given input
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "col1 > 1",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "col1 value must be greater than 1",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "10",
+                }
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            # expected res
+            spark.createDataFrame(
+                [
+                    {"col1": 1, "col2": "a"},
+                    {"col1": 2, "col2": "b"},
+                    {"col1": 3, "col2": "c"},
+                ]
+            ),
+            3,  # input count
+            1,  # error count
+            3,  # output count
+            None,  # source_agg_dq_res
+            None,  # final_agg_dq_res
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
                 },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
+                },
+            },  # dq_rules
+            # status at different stages for given input
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
         ),
         (
-                # test case 1
-                # In this test case, the action for failed rows is "drop",
-                # collect stats in the test_stats_table and
-                # log the error records into the error table.
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row  meets expectations(drop), log into err & fnl
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row doesn't meets expectations(drop), log into final table
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets expectations(drop), log into final table
-                    ]
-                ),
+            # test case 1
+            # In this test case, the action for failed rows is "drop",
+            # collect stats in the test_stats_table and
+            # log the error records into the error table.
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col2_set",
-                        "column_name": "col2",
-                        "expectation": "col2 in  ('a', 'c')",
-                        "action_if_failed": "drop",
-                        "tag": "strict",
-                        "description": "col2 value must be in ('a', 'b')",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "5",
-                    }
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                # expected res
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet expectations(ignore), log into err & fnl
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets expectations(ignore), log into final table
-                    ]
-                ),
-                3,  # input count
-                1,  # error count
-                2,  # output count
-                None,  # source_agg_dq_res
-                None,  # final_agg_dq_res
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row  meets expectations(drop), log into err & fnl
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row doesn't meets expectations(drop), log into final table
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets expectations(drop), log into final table
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
-                },  # dq_rules
-                # status at different stages for given input
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col2_set",
+                    "column_name": "col2",
+                    "expectation": "col2 in  ('a', 'c')",
+                    "action_if_failed": "drop",
+                    "tag": "strict",
+                    "description": "col2 value must be in ('a', 'b')",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "5",
+                }
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            # expected res
+            spark.createDataFrame(
+                [
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet expectations(ignore), log into err & fnl
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets expectations(ignore), log into final table
+                ]
+            ),
+            3,  # input count
+            1,  # error count
+            2,  # output count
+            None,  # source_agg_dq_res
+            None,  # final_agg_dq_res
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
                 },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
+                },
+            },  # dq_rules
+            # status at different stages for given input
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
         ),
         (
-                # test case 2
-                # In this test case, the action for failed rows is "fail",
-                # spark expectations expected to fail
-                # collect stats in the test_stats_table and
-                # log the error records into the error table.
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet expectations(fail), log into err & fnl
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets doesn't expectations(fail), log into final table
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets doesn't expectations(fail), log into final table
-                    ]
-                ),
+            # test case 2
+            # In this test case, the action for failed rows is "fail",
+            # spark expectations expected to fail
+            # collect stats in the test_stats_table and
+            # log the error records into the error table.
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "col3 > 6",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                        "description": "col3 value must be greater than 6",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "15",
-                    }
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                SparkExpectationsMiscException,  # expected res
-                3,  # input count
-                3,  # error count
-                0,  # output count
-                None,  # source_agg_dq_res
-                None,  # final_agg_dq_res
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet expectations(fail), log into err & fnl
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets doesn't expectations(fail), log into final table
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets doesn't expectations(fail), log into final table
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
-                },  # dq_rules
-                # status at different stages for given input
-                {
-                    "row_dq_status": "Failed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Failed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "col3 > 6",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                    "description": "col3 value must be greater than 6",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "15",
+                }
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            SparkExpectationsMiscException,  # expected res
+            3,  # input count
+            3,  # error count
+            0,  # output count
+            None,  # source_agg_dq_res
+            None,  # final_agg_dq_res
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
                 },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
+                },
+            },  # dq_rules
+            # status at different stages for given input
+            {
+                "row_dq_status": "Failed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Failed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
         ),
         (  # test case 3
-                # In this test case, the action for failed rows is "ignore" & "drop",
-                # collect stats in the test_stats_table and
-                # log the error records into the error table.
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet expectations1(ignore) 2(drop), log into err & fnl
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets expectations1(ignore), log into final table
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row doesnt'meets expectations1(ignore), log into final table
-                    ]
-                ),
+            # In this test case, the action for failed rows is "ignore" & "drop",
+            # collect stats in the test_stats_table and
+            # log the error records into the error table.
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "col3 > 6",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                        "description": "col3 value must be greater than 6",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "10",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col1_add_col3_threshold",
-                        "column_name": "col1",
-                        "expectation": "(col1+col3) > 6",
-                        "action_if_failed": "drop",
-                        "tag": "strict",
-                        "description": "col1_add_col3 value must be greater than 6",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "15",
-                    },
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                # expected res
-                spark.createDataFrame(
-                    [
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),
-                3,  # input count
-                3,  # error count
-                2,  # output count
-                None,  # source_agg_dq_res
-                None,  # final_agg_dq_res
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet expectations1(ignore) 2(drop), log into err & fnl
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets expectations1(ignore), log into final table
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row doesnt'meets expectations1(ignore), log into final table
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
-                },  # dq_rules
-                # status at different stages for given input
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "col3 > 6",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                    "description": "col3 value must be greater than 6",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "10",
                 },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col1_add_col3_threshold",
+                    "column_name": "col1",
+                    "expectation": "(col1+col3) > 6",
+                    "action_if_failed": "drop",
+                    "tag": "strict",
+                    "description": "col1_add_col3 value must be greater than 6",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "15",
+                },
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            # expected res
+            spark.createDataFrame(
+                [
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),
+            3,  # input count
+            3,  # error count
+            2,  # output count
+            None,  # source_agg_dq_res
+            None,  # final_agg_dq_res
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
+                },
+            },  # dq_rules
+            # status at different stages for given input
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
         ),
         (
-                # test case 4
-                # In this test case, the action for failed rows is "ignore" & "fail",
-                # collect stats in the test_stats_table and
-                # log the error records into the error table.
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet expectations1(ignore), log into err & fnl
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets expectations1(ignore), log into final table
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets expectations1(ignore), log into final table
-                    ]
-                ),
+            # test case 4
+            # In this test case, the action for failed rows is "ignore" & "fail",
+            # collect stats in the test_stats_table and
+            # log the error records into the error table.
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "col3 > 6",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                        "description": "col3 value must be greater than 6",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_minus_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(col3-col1) > 1",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                        "description": "col3_minus_col1 value must be greater than 1",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "5",
-                    },
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                # expected res
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),
-                3,  # input count
-                3,  # error count
-                3,  # output count
-                None,  # source_agg_dq_res
-                None,  # final_agg_dq_res
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet expectations1(ignore), log into err & fnl
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets expectations1(ignore), log into final table
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets expectations1(ignore), log into final table
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
-                },  # dq_rules
-                # status at different stages for given input
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "col3 > 6",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                    "description": "col3 value must be greater than 6",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "20",
                 },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_minus_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(col3-col1) > 1",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                    "description": "col3_minus_col1 value must be greater than 1",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "5",
+                },
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            # expected res
+            spark.createDataFrame(
+                [
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),
+            3,  # input count
+            3,  # error count
+            3,  # output count
+            None,  # source_agg_dq_res
+            None,  # final_agg_dq_res
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
+                },
+            },  # dq_rules
+            # status at different stages for given input
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
         ),
         (
-                # Test case 5
-                # In this test case, the action for failed rows is "drop" & "fail",
-                # collect stats in the test_stats_table and
-                # log the error records into the error table.
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet expectations1(drop) & 2(drop), log into err & fnl
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets expectations1(drop) & 2(fail), log into final table
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets expectations1(drop), & 2(fail) log into final table
-                    ]
-                ),
+            # Test case 5
+            # In this test case, the action for failed rows is "drop" & "fail",
+            # collect stats in the test_stats_table and
+            # log the error records into the error table.
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "col3 > 6",
-                        "action_if_failed": "drop",
-                        "tag": "strict",
-                        "description": "col3 value must be greater than 6",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "25",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_minus_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(col3-col1) = 1",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                        "description": "col3_minus_col1 value must be equals to 1",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "25",
-                    },
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                SparkExpectationsMiscException,  # expected res
-                3,  # input count
-                3,  # error count
-                0,  # output count
-                None,  # source_agg_dq_res
-                None,  # final_agg_dq_res
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet expectations1(drop) & 2(drop), log into err & fnl
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets expectations1(drop) & 2(fail), log into final table
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets expectations1(drop), & 2(fail) log into final table
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
-                },  # dq_rules
-                # status at different stages for given input
-                {
-                    "row_dq_status": "Failed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Failed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "col3 > 6",
+                    "action_if_failed": "drop",
+                    "tag": "strict",
+                    "description": "col3 value must be greater than 6",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "25",
                 },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_minus_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(col3-col1) = 1",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                    "description": "col3_minus_col1 value must be equals to 1",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "25",
+                },
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            SparkExpectationsMiscException,  # expected res
+            3,  # input count
+            3,  # error count
+            0,  # output count
+            None,  # source_agg_dq_res
+            None,  # final_agg_dq_res
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
+                },
+            },  # dq_rules
+            # status at different stages for given input
+            {
+                "row_dq_status": "Failed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Failed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
         ),
         (  # Test case 6
-                # In this test case, the action for failed rows is "drop" & "fail",
-                # collect stats in the test_stats_table and
-                # log the error records into the error table
-                spark.createDataFrame(
+            # In this test case, the action for failed rows is "drop" & "fail",
+            # collect stats in the test_stats_table and
+            # log the error records into the error table
+            spark.createDataFrame(
+                [
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet expectations1(drop) & meets 2(fail), log into err & fnl
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets expectations1(drop) & meets 2(fail), log into final table
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets expectations1(drop) & meets 2(fail), log into final table
+                ]
+            ),
+            [
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "col3 > 6",
+                    "action_if_failed": "drop",
+                    "tag": "strict",
+                    "description": "col3 value must be greater than 6",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "10",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_mul_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(col3*col1) > 1",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                    "description": "col3_mul_col1 value must be equals to 1",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "10",
+                },
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            # expected res
+            spark.createDataFrame(
+                [],
+                schema=StructType(
                     [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet expectations1(drop) & meets 2(fail), log into err & fnl
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets expectations1(drop) & meets 2(fail), log into final table
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets expectations1(drop) & meets 2(fail), log into final table
+                        StructField("col1", IntegerType()),
+                        StructField("col2", StringType()),
+                        StructField("col3", IntegerType()),
                     ]
                 ),
+            ),
+            3,  # input count
+            3,  # error count
+            0,  # output count
+            None,  # source_agg_dq_res
+            None,  # final_agg_dq_res
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
+                },
+            },  # dq_rules
+            # status at different stages for given input
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
+        ),
+        (
+            # Test case 7
+            # In this test case, the action for failed rows is "ignore", "drop" & "fail",
+            # collect stats in the test_stats_table and
+            # log the error records into the error table
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "col3 > 6",
-                        "action_if_failed": "drop",
-                        "tag": "strict",
-                        "description": "col3 value must be greater than 6",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "10",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_mul_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(col3*col1) > 1",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                        "description": "col3_mul_col1 value must be equals to 1",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "10",
-                    },
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                # expected res
-                spark.createDataFrame(
-                    [],
-                    schema=StructType(
-                        [
-                            StructField("col1", IntegerType()),
-                            StructField("col2", StringType()),
-                            StructField("col3", IntegerType()),
-                        ]
-                    ),
-                ),
-                3,  # input count
-                3,  # error count
-                0,  # output count
-                None,  # source_agg_dq_res
-                None,  # final_agg_dq_res
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet the expectation1(ignore) & expectation2(drop)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row doesn't meet the expectation2(drop)
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all the expectations
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "col1 > 1",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                    "description": "col1 value must be greater than 1",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "0",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "col3 > 5",
+                    "action_if_failed": "drop",
+                    "tag": "strict",
+                    "description": "col3 value must be greater than 5",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "10",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_mul_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(col3*col1) > 1",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                    "description": "col3_mul_col1 value must be equals to 1",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            True,  # write to table
+            True,  # write_to_temp_table
+            spark.createDataFrame(  # expected output
+                [
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),
+            3,  # input count
+            2,  # error count
+            1,  # output count
+            None,  # source_agg_result
+            None,  # final_agg_result
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 3, "num_row_dq_rules": 3},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
+                },
+            },  # dq_rules
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",  # status
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
+        ),
+        (
+            # Test case 8
+            # In this test case, dq run set for source_agg_dq
+            # collect stats in the test_stats_table
+            spark.createDataFrame(
+                [
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),
+            [
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "agg_dq",
+                    "rule": "sum_col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "sum(col3) > 20",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                    "description": "sum col3 value must be greater than 20",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "10",
+                }
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            spark.createDataFrame(
+                [
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),  # expected result
+            3,  # input count
+            0,  # error count
+            0,  # output count
+            [
+                {
+                    "description": "sum col3 value must be greater than 20",  # source_ag_result
+                    "rule": "sum_col3_threshold",
+                    "rule_type": "agg_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                }
+            ],
+            None,  # final_agg_result
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 1,
+                    "num_agg_dq_rules": 1,
+                    "num_final_agg_dq_rules": 1,
+                },
+            },  # dq_rules
+            {
+                "row_dq_status": "Skipped",
+                "source_agg_dq_status": "Passed",  # status
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
+        ),
+        (
+            # Test case 9
+            # In this test case, dq run set for source_agg_dq with action_if_failed fail
+            # collect stats in the test_stats_table
+            spark.createDataFrame(
+                [
+                    # avg of col3 is not more than 25
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),
+            [
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "agg_dq",
+                    "rule": "avg_col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "avg(col3) > 25",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                    "description": "avg col3 value must be greater than 25",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                }
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            SparkExpectationsMiscException,  # excepted result
+            3,  # input count
+            0,  # error count
+            0,  # output count
+            [
+                {
+                    "description": "avg col3 value must be greater than 25",  # source_agg_result
+                    "rule": "avg_col3_threshold",
+                    "rule_type": "agg_dq",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                }
+            ],
+            None,  # final_agg_result
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 1,
+                    "num_agg_dq_rules": 1,
+                    "num_final_agg_dq_rules": 1,
+                },
+            },  # dq_rules
+            {
+                "row_dq_status": "Skipped",
+                "source_agg_dq_status": "Failed",  # status
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Failed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
+        ),
+        (
+            # Test case 10
+            # In this test case, dq run set for final_agg_dq with action_if_failed ignore
+            # collect stats in the test_stats_table
+            spark.createDataFrame(
+                [
+                    # minimum of col1 must be greater than 10
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),
+            [
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "agg_dq",
+                    "rule": "min_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "min(col1) > 10",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                    "description": "min col1 value must be greater than 10",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col2_set",
+                    "column_name": "col2",
+                    "expectation": "col2 in  ('a', 'c')",
+                    "action_if_failed": "drop",
+                    "tag": "strict",
+                    "description": "col2 value must be in ('a', 'b')",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "0",
+                },
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            spark.createDataFrame(
+                [
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),  # expected result but row_dq set to false
+            3,  # input count
+            1,  # error count
+            2,  # output count
+            None,  # source_agg-result
+            [
+                {
+                    "description": "min col1 value must be greater than 10",
+                    "rule": "min_col1_threshold",
+                    "rule_type": "agg_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                }
+            ],
+            # final_agg_result
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 1},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 1,
+                    "num_agg_dq_rules": 1,
+                    "num_final_agg_dq_rules": 1,
+                },
+            },  # dq_rules
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Passed",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
+        ),
+        (
+            # Test case 11
+            # In this test case, dq run set for row_dq & final_agg_dq
+            # with action_if_failed drop(row), fail(agg)
+            # collect stats in the test_stats_table & error into error_table
+            spark.createDataFrame(
+                # standard deviation of col3 must be greater than 10
+                [
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row meet expectation
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row doesn't meet expectation
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets expectations
+                ]
+            ),
+            [
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "agg_dq",
+                    "rule": "std_col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "stddev(col3) > 10",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                    "description": "std col3 value must be greater than 10",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col2_set",
+                    "column_name": "col2",
+                    "expectation": "col2 in  ('a', 'c')",
+                    "action_if_failed": "drop",
+                    "tag": "strict",
+                    "description": "col2 value must be in ('a', 'b')",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "15",
+                },
+            ],
+            True,  # write to table
+            True,  # write temp table
+            SparkExpectationsMiscException,  # expected result
+            3,  # input count
+            1,  # error count
+            2,  # output count
+            None,  # source_agg_result
+            [
+                {
+                    "description": "std col3 value must be greater than 10",
+                    "rule": "std_col3_threshold",
+                    "rule_type": "agg_dq",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                }
+            ],
+            # final_agg_result
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 1},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 1,
+                    "num_agg_dq_rules": 1,
+                    "num_final_agg_dq_rules": 1,
+                },
+            },  # dq_rules
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Failed",
+                "run_status": "Failed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
+            # status
+        ),
+        (
+            # Test case 12
+            # In this test case, dq run set for row_dq
+            # with action_if_failed drop
+            # collect stats in the test_stats_table & error into error_table
+            spark.createDataFrame(
+                [
+                    {"col1": 1, "col2": "a"},
+                    # row doesn't meet the expectations
+                    {"col1": 2, "col2": "b"},
+                    # row meets the expectation
+                    {"col1": 3, "col2": "c"},
+                    # row meets the expectations
+                ]
+            ),
+            [
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "col1 > 1",
+                    "action_if_failed": "drop",
+                    "tag": "validity",
+                    "description": "col1 value must be greater than 1",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "0",
+                }
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            spark.createDataFrame(
+                [{"col1": 2, "col2": "b"}, {"col1": 3, "col2": "c"}]  # expected_output
+            ),  # expected result
+            3,  # input count
+            1,  # error count
+            2,  # output count
+            None,  # source_agg_result
+            None,  # final_agg_result
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
+                },
+            },  # dq_rules
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },  # status
+        ),
+        (
+            # Test case 13
+            # In this test case, dq run set for row_dq  & source_agg_dq
+            # with action_if_failed (ignore, drop) and ignore(agg_dq)
+            # collect stats in the test_stats_table & error into error_table
+            spark.createDataFrame(
+                [
+                    # count of distinct element in col2 must be greater than 2
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet expectation1(ignore)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets all row_dq expectations
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all row_dq expectations
+                ]
+            ),
+            [
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col1_threshold_1",
+                    "column_name": "col1",
+                    "expectation": "col1 > 1",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "col1 value must be greater than 1",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "10",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col2_set",
+                    "column_name": "col2",
+                    "expectation": "col2 in ('a', 'b', 'c')",
+                    "action_if_failed": "drop",
+                    "tag": "validity",
+                    "description": "col1 value must be greater than 2",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "10",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "agg_dq",
+                    "rule": "distinct_col2_threshold",
+                    "column_name": "col2",
+                    "expectation": "count(distinct col2) > 4",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "distinct of col2 value must be greater than 4",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            spark.createDataFrame(
+                [  # expected_output
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),
+            3,  # input count
+            1,  # error count
+            3,  # output count
+            [
+                {
+                    "description": "distinct of col2 value must be greater than 4",
+                    "rule": "distinct_col2_threshold",
+                    "rule_type": "agg_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                }
+            ],
+            # source_agg_result
+            None,  # final_agg_result
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 3, "num_row_dq_rules": 2},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 1,
+                    "num_agg_dq_rules": 1,
+                    "num_final_agg_dq_rules": 1,
+                },
+            },  # dq_rules
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Passed",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },  # status
+        ),
+        (
+            # Test case 14
+            # In this test case, dq run set for row_dq, source_agg_dq & final_agg_dq
+            # with action_if_failed r(ignore, drop) for row_dq  and (ignore) for agg_dq
+            # collect stats in the test_stats_table & error into error_table
+            spark.createDataFrame(
+                [
+                    # avg of col1 must be greater than 4(ignore) for agg_dq
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet row_dq expectation1(ignore)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row doesn't meet row_dq expectation2(drop)
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all row-dq expectations
+                ]
+            ),
+            [
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_threshold_4",
+                    "column_name": "col3",
+                    "expectation": "col3 > 4",
+                    "action_if_failed": "drop",
+                    "tag": "validity",
+                    "description": "col3 value must be greater than 4",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col2_set",
+                    "column_name": "col2",
+                    "expectation": "col2 in ('a', 'b')",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "col2 value must be in (a, b)",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "2",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "agg_dq",
+                    "rule": "avg_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "avg(col1) > 4",
+                    "action_if_failed": "ignore",
+                    "tag": "accuracy",
+                    "description": "avg of col1 value must be greater than 4",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            spark.createDataFrame(
+                [  # expected_output
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),  # expected result
+            3,  # input count
+            2,  # error count
+            2,  # output count
+            [
+                {
+                    "description": "avg of col1 value must be greater than 4",
+                    "rule": "avg_col1_threshold",
+                    "rule_type": "agg_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "accuracy",
+                }
+            ],
+            # source_agg_dq
+            [
+                {
+                    "description": "avg of col1 value must be greater than 4",
+                    "rule": "avg_col1_threshold",
+                    "rule_type": "agg_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "accuracy",
+                }
+            ],
+            # final_agg_dq
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 3, "num_row_dq_rules": 2},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
+                },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 1,
+                    "num_agg_dq_rules": 1,
+                    "num_final_agg_dq_rules": 1,
+                },
+            },  # dq_rules
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Passed",
+                "final_agg_dq_status": "Passed",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },  # status
+        ),
+        (
+            # Test case 15
+            # In this test case, dq run set for row_dq, source_agg_dq & final_agg_dq
+            # with action_if_failed (ignore, drop) for row_dq  and (ignore, fail) for agg_dq
+            # collect stats in the test_stats_table & error into error_table
+            spark.createDataFrame(
+                [
+                    # average of col1 must be greater than 4(ignore)
+                    # standard deviation of col1 must be greater than 0(fail)
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets all row_dq_expectations
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all row_dq_expectations
+                    {"col1": 2, "col2": "d", "col3": 7},
+                ]
+            ),
+            [
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_and_col1_threshold_4",
+                    "column_name": "col3, col1",
+                    "expectation": "((col3 * col1) - col3) > 5",
+                    "action_if_failed": "drop",
+                    "tag": "validity",
+                    "description": "col3 and col1 operation value must be greater than 3",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "25",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col2_set",
+                    "column_name": "col2",
+                    "expectation": "col2 in ('b', 'c')",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "col2 value must be in (b, c)",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "30",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "agg_dq",
+                    "rule": "avg_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "avg(col1) > 4",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "avg of col1 value must be greater than 4",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "agg_dq",
+                    "rule": "stddev_col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "stddev(col3) > 1",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "stddev of col3 value must be greater than one",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            spark.createDataFrame(
+                [  # expected_output
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    {"col1": 2, "col2": "d", "col3": 7},
+                ]
+            ),  # expected result
+            4,  # input count
+            3,  # error count
+            2,  # output count
+            [
+                {
+                    "description": "avg of col1 value must be greater than 4",
+                    "rule": "avg_col1_threshold",
+                    "rule_type": "agg_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                }
+            ],
+            # source_agg_result
+            [
+                {
+                    "action_if_failed": "ignore",
+                    "description": "avg of col1 value must be greater than 4",
+                    "rule": "avg_col1_threshold",
+                    "rule_type": "agg_dq",
+                    "tag": "validity",
+                },
+                {
+                    "action_if_failed": "ignore",
+                    "description": "stddev of col3 value must be greater than one",
+                    "rule": "stddev_col3_threshold",
+                    "rule_type": "agg_dq",
+                    "tag": "validity",
+                },
+            ],
+            # final_agg_result
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 5, "num_row_dq_rules": 2},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
                 },  # dq_rules
-                # status at different stages for given input
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 2,
+                    "num_agg_dq_rules": 3,
+                    "num_final_agg_dq_rules": 2,
                 },
+            },
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Passed",
+                "final_agg_dq_status": "Passed",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },  # status
         ),
         (
-                # Test case 7
-                # In this test case, the action for failed rows is "ignore", "drop" & "fail",
-                # collect stats in the test_stats_table and
-                # log the error records into the error table
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet the expectation1(ignore) & expectation2(drop)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row doesn't meet the expectation2(drop)
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all the expectations
-                    ]
-                ),
+            # Test case 16
+            # In this test case, dq run set for query_dq source_query_dq
+            # with action_if_failed (ignore) for query_dq
+            # collect stats in the test_stats_table & error into error_table
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "col1 > 1",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                        "description": "col1 value must be greater than 1",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "0",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "col3 > 5",
-                        "action_if_failed": "drop",
-                        "tag": "strict",
-                        "description": "col3 value must be greater than 5",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "10",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_mul_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(col3*col1) > 1",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                        "description": "col3_mul_col1 value must be equals to 1",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                True,  # write to table
-                True,  # write_to_temp_table
-                spark.createDataFrame(  # expected output
-                    [
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),
-                3,  # input count
-                2,  # error count
-                1,  # output count
-                None,  # source_agg_result
-                None,  # final_agg_result
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    # sum of col1 must be greater than 10(ignore)
+                    # standard deviation of col3 must be greater than 0(ignore)
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet row_dq expectation1(drop)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets all row_dq_expectations
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all row_dq_expectations
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 3, "num_row_dq_rules": 3},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "sum_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(select sum(col1) from test_table) > 10",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "sum of col1 value must be greater than 10",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "stddev_col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "(select stddev(col3) from test_table) > 0",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "stddev of col3 value must be greater than 0",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            False,  # write to table
+            False,  # write to temp table
+            None,  # expected result
+            3,  # input count
+            0,  # error count
+            0,  # output count
+            None,  # source_agg_result
+            None,  # final_agg_result
+            # final_agg_result
+            [
+                {
+                    "description": "sum of col1 value must be greater than 10",
+                    "rule": "sum_col1_threshold",
+                    "rule_type": "query_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                }
+            ],
+            # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 2,
+                    "num_source_query_dq_rules": 2,
+                    "num_query_dq_rules": 2,
                 },  # dq_rules
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",  # status
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
                 },
+            },
+            {
+                "row_dq_status": "Skipped",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Passed",
+                "final_query_dq_status": "Skipped",
+            },  # status
         ),
         (
-                # Test case 8
-                # In this test case, dq run set for source_agg_dq
-                # collect stats in the test_stats_table
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),
+            # Test case 17
+            # In this test case, dq run set for query_dq final_query_dq
+            # with action_if_failed (ignore) for query_dq
+            # collect stats in the test_stats_table & error into error_table
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "agg_dq",
-                        "rule": "sum_col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "sum(col3) > 20",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                        "description": "sum col3 value must be greater than 20",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "10",
-                    }
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),  # expected result
-                3,  # input count
-                0,  # error count
-                0,  # output count
-                [
-                    {
-                        "description": "sum col3 value must be greater than 20",  # source_ag_result
-                        "rule": "sum_col3_threshold",
-                        "rule_type": "agg_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                    }
-                ],
-                None,  # final_agg_result
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    # max of col1 must be greater than 10(ignore)
+                    # min of col3 must be greater than 0(ignore)
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets all row_dq_expectations
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all row_dq_expectations
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 1,
-                        "num_agg_dq_rules": 1,
-                        "num_final_agg_dq_rules": 1,
-                    },
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_and_col1_threshold_4",
+                    "column_name": "col3, col1",
+                    "expectation": "((col3 * col1) - col3) > 5",
+                    "action_if_failed": "drop",
+                    "tag": "validity",
+                    "description": "col3 and col1 operation value must be greater than 3",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "max_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(select max(col1) from test_final_table_view) > 10",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                    "description": "max of col1 value must be greater than 10",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "min_col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "(select min(col3) from test_final_table_view) > 0",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "min of col3 value must be greater than 0",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            True,  # write to table
+            False,  # write to temp table
+            spark.createDataFrame(
+                [
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),  # expected result
+            3,  # input count
+            2,  # error count
+            1,  # output count
+            None,  # source_agg_result
+            None,  # final_agg_result
+            # final_agg_result
+            None,  # source_query_dq_res
+            [
+                {
+                    "description": "max of col1 value must be greater than 10",
+                    "rule": "max_col1_threshold",
+                    "rule_type": "query_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                }
+            ],
+            # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 3, "num_row_dq_rules": 1},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 2,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 2,
                 },  # dq_rules
-                {
-                    "row_dq_status": "Skipped",
-                    "source_agg_dq_status": "Passed",  # status
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
                 },
+            },
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Passed",
+            },  # status
         ),
         (
-                # Test case 9
-                # In this test case, dq run set for source_agg_dq with action_if_failed fail
-                # collect stats in the test_stats_table
-                spark.createDataFrame(
-                    [
-                        # avg of col3 is not more than 25
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),
+            # Test case 18
+            # In this test case, dq run set for query_dq source_query_dq(ignore, fail)
+            # with action_if_failed (fail) for query_dq
+            # collect stats in the test_stats_table, error into error_table & raises the error
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "agg_dq",
-                        "rule": "avg_col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "avg(col3) > 25",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                        "description": "avg col3 value must be greater than 25",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    }
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                SparkExpectationsMiscException,  # excepted result
-                3,  # input count
-                0,  # error count
-                0,  # output count
-                [
-                    {
-                        "description": "avg col3 value must be greater than 25",  # source_agg_result
-                        "rule": "avg_col3_threshold",
-                        "rule_type": "agg_dq",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                    }
-                ],
-                None,  # final_agg_result
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    # min of col1 must be greater than 10(fail)
+                    # standard deviation of col3 must be greater than 0(ignore)
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet row_dq expectation1(drop)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets all row_dq_expectations
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all row_dq_expectations
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 1,
-                        "num_agg_dq_rules": 1,
-                        "num_final_agg_dq_rules": 1,
-                    },
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "min_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(select min(col1) from test_final_table_view) > 10",
+                    "action_if_failed": "fail",
+                    "tag": "validity",
+                    "description": "min of col1 value must be greater than 10",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "stddev_col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "(select stddev(col3) from test_final_table_view) > 0",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "stddev of col3 value must be greater than 0",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            False,  # write to table
+            False,  # write to temp table
+            SparkExpectationsMiscException,  # expected result
+            3,  # input count
+            0,  # error count
+            0,  # output count
+            None,  # source_agg_result
+            None,  # final_agg_result
+            [
+                {
+                    "action_if_failed": "fail",
+                    "description": "min of col1 value must be greater than 10",
+                    "rule": "min_col1_threshold",
+                    "rule_type": "query_dq",
+                    "tag": "validity",
+                },
+                {
+                    "action_if_failed": "ignore",
+                    "description": "stddev of col3 value must be greater than 0",
+                    "rule": "stddev_col3_threshold",
+                    "rule_type": "query_dq",
+                    "tag": "validity",
+                },
+            ],  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 2,
+                    "num_source_query_dq_rules": 2,
+                    "num_query_dq_rules": 2,
                 },  # dq_rules
-                {
-                    "row_dq_status": "Skipped",
-                    "source_agg_dq_status": "Failed",  # status
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Failed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
                 },
+            },
+            {
+                "row_dq_status": "Skipped",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Failed",
+                "source_query_dq_status": "Failed",
+                "final_query_dq_status": "Skipped",
+            },  # status
         ),
         (
-                # Test case 10
-                # In this test case, dq run set for final_agg_dq with action_if_failed ignore
-                # collect stats in the test_stats_table
-                spark.createDataFrame(
-                    [
-                        # minimum of col1 must be greater than 10
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),
+            # Test case 19
+            # In this test case, dq run set for query_dq final_query_dq(ignore, fail)
+            # with action_if_failed (ignore, fail) for query_dq
+            # collect stats in the test_stats_table, error into error_table & raises error
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "agg_dq",
-                        "rule": "min_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "min(col1) > 10",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                        "description": "min col1 value must be greater than 10",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col2_set",
-                        "column_name": "col2",
-                        "expectation": "col2 in  ('a', 'c')",
-                        "action_if_failed": "drop",
-                        "tag": "strict",
-                        "description": "col2 value must be in ('a', 'b')",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "0",
-                    },
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),  # expected result but row_dq set to false
-                3,  # input count
-                1,  # error count
-                2,  # output count
-                None,  # source_agg-result
-                [
-                    {
-                        "description": "min col1 value must be greater than 10",
-                        "rule": "min_col1_threshold",
-                        "rule_type": "agg_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                    }
-                ],
-                # final_agg_result
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    # max of col1 must be greater than 10(ignore)
+                    # min of col3 must be greater than 0(ignore)
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets all row_dq_expectations
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all row_dq_expectations
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 1},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 1,
-                        "num_agg_dq_rules": 1,
-                        "num_final_agg_dq_rules": 1,
-                    },
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_and_col1_threshold_4",
+                    "column_name": "col3, col1",
+                    "expectation": "((col3 * col1) - col3) > 5",
+                    "action_if_failed": "drop",
+                    "tag": "validity",
+                    "description": "col3 and col1 operation value must be greater than 3",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "25",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "max_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(select max(col1) from test_final_table_view) > 10",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                    "description": "max of col1 value must be greater than 10",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "min_col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "(select min(col3) from test_final_table_view) > 0",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "min of col3 value must be greater than 0",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            True,  # write to table
+            False,  # write to temp table
+            SparkExpectationsMiscException,  # expected result
+            3,  # input count
+            2,  # error count
+            1,  # output count
+            None,  # source_agg_result
+            None,  # final_agg_result
+            # final_agg_result
+            None,  # source_query_dq_res
+            [
+                {
+                    "description": "max of col1 value must be greater than 10",
+                    "rule": "max_col1_threshold",
+                    "rule_type": "query_dq",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                }
+            ],
+            # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 3, "num_row_dq_rules": 1},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 2,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 2,
                 },  # dq_rules
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Passed",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
                 },
+            },
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Failed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Failed",
+            },  # status
         ),
         (
-                # Test case 11
-                # In this test case, dq run set for row_dq & final_agg_dq
-                # with action_if_failed drop(row), fail(agg)
-                # collect stats in the test_stats_table & error into error_table
-                spark.createDataFrame(
-                    # standard deviation of col3 must be greater than 10
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row meet expectation
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row doesn't meet expectation
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets expectations
-                    ]
-                ),
+            # Test case 20
+            # In this test case, dq run set for query_dq source_query_dq &
+            # final_query_dq(ignore, fail)
+            # with action_if_failed (ignore, fail) for query_dq
+            # collect stats in the test_stats_table, error into error_table
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "agg_dq",
-                        "rule": "std_col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "stddev(col3) > 10",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                        "description": "std col3 value must be greater than 10",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col2_set",
-                        "column_name": "col2",
-                        "expectation": "col2 in  ('a', 'c')",
-                        "action_if_failed": "drop",
-                        "tag": "strict",
-                        "description": "col2 value must be in ('a', 'b')",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "15",
-                    },
-                ],
-                True,  # write to table
-                True,  # write temp table
-                SparkExpectationsMiscException,  # expected result
-                3,  # input count
-                1,  # error count
-                2,  # output count
-                None,  # source_agg_result
-                [
-                    {
-                        "description": "std col3 value must be greater than 10",
-                        "rule": "std_col3_threshold",
-                        "rule_type": "agg_dq",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                    }
-                ],
-                # final_agg_result
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    # min of col1 must be greater than 10(ignore) - source_query_dq
+                    # max of col1 must be greater than 100(ignore) - final_query_dq
+                    # min of col3 must be greater than 0(fail) - final_query_dq
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row meets all row_dq_expectations(drop)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # ow doesn't meet row_dq expectation1(drop)
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all row_dq_expectations
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 1},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 1,
-                        "num_agg_dq_rules": 1,
-                        "num_final_agg_dq_rules": 1,
-                    },
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_mod_2",
+                    "column_name": "col3",
+                    "expectation": "(col3 % 2) = 0",
+                    "action_if_failed": "drop",
+                    "tag": "validity",
+                    "description": "col3 mod must equals to 0",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": True,
+                    "error_drop_threshold": "40",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "min_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(select min(col1) from test_final_table_view) > 10",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                    "description": "min of col1 value must be greater than 10",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "max_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(select max(col1) from test_final_table_view) > 100",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                    "description": "max of col1 value must be greater than 100",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "min_col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "(select min(col3) from test_final_table_view) > 0",
+                    "action_if_failed": "fail",
+                    "tag": "validity",
+                    "description": "min of col3 value must be greater than 0",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            True,  # write to table
+            False,  # write to temp table
+            spark.createDataFrame(
+                [
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),  # expected result
+            3,  # input count
+            1,  # error count
+            2,  # output count
+            None,  # source_agg_result
+            None,  # final_agg_result
+            # final_agg_result
+            [
+                {
+                    "description": "min of col1 value must be greater than 10",
+                    "rule": "min_col1_threshold",
+                    "rule_type": "query_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                }
+            ],
+            # source_query_dq_res
+            [
+                {
+                    "description": "max of col1 value must be greater than 100",
+                    "rule": "max_col1_threshold",
+                    "rule_type": "query_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                }
+            ],
+            # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 2,
+                    "num_source_query_dq_rules": 1,
+                    "num_query_dq_rules": 3,
                 },  # dq_rules
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Failed",
-                    "run_status": "Failed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
                 },
-                # status
+            },
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Passed",
+                "final_query_dq_status": "Passed",
+            },  # status
         ),
         (
-                # Test case 12
-                # In this test case, dq run set for row_dq
-                # with action_if_failed drop
-                # collect stats in the test_stats_table & error into error_table
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a"},
-                        # row doesn't meet the expectations
-                        {"col1": 2, "col2": "b"},
-                        # row meets the expectation
-                        {"col1": 3, "col2": "c"},
-                        # row meets the expectations
-                    ]
-                ),
+            # Test case 21
+            # In this test case, dq run set for query_dq source_query_dq &
+            # final_query_dq(ignore, fail)
+            # with action_if_failed (ignore, fail) for query_dq
+            # collect stats in the test_stats_table, error into error_table & raise the error
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "col1 > 1",
-                        "action_if_failed": "drop",
-                        "tag": "validity",
-                        "description": "col1 value must be greater than 1",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "0",
-                    }
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                spark.createDataFrame(
-                    [{"col1": 2, "col2": "b"}, {"col1": 3, "col2": "c"}]  # expected_output
-                ),  # expected result
-                3,  # input count
-                1,  # error count
-                2,  # output count
-                None,  # source_agg_result
-                None,  # final_agg_result
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    # min of col1 must be greater than 10(ignore) - source_query_dq
+                    # max of col1 must be greater than 100(fail) - final_query_dq
+                    # min of col3 must be greater than 0(fail) - final_query_dq
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row meets all row_dq_expectations(drop)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # ow doesn't meet row_dq expectation1(drop)
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all row_dq_expectations
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_mod_2",
+                    "column_name": "col3",
+                    "expectation": "(col3 % 2) = 0",
+                    "action_if_failed": "drop",
+                    "tag": "validity",
+                    "description": "col3 mod must equals to 0",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "10",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "min_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(select min(col1) from test_final_table_view) > 10",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                    "description": "min of col1 value must be greater than 10",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "max_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(select max(col1) from test_final_table_view) > 100",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                    "description": "max of col1 value must be greater than 100",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "min_col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "(select min(col3) from test_final_table_view) > 0",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "min of col3 value must be greater than 0",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            True,  # write to table
+            False,  # write to temp table
+            SparkExpectationsMiscException,  # expected result
+            3,  # input count
+            1,  # error count
+            2,  # output count
+            None,  # source_agg_result
+            None,  # final_agg_result
+            # final_agg_result
+            [
+                {
+                    "description": "min of col1 value must be greater than 10",
+                    "rule": "min_col1_threshold",
+                    "rule_type": "query_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                }
+            ],
+            # source_query_dq_res
+            [
+                {
+                    "description": "max of col1 value must be greater than 100",
+                    "rule": "max_col1_threshold",
+                    "rule_type": "query_dq",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                }
+            ],
+            # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 2,
+                    "num_source_query_dq_rules": 1,
+                    "num_query_dq_rules": 3,
                 },  # dq_rules
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
-                },  # status
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
+                },
+            },
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Failed",
+                "source_query_dq_status": "Passed",
+                "final_query_dq_status": "Failed",
+            },  # status
         ),
         (
-                # Test case 13
-                # In this test case, dq run set for row_dq  & source_agg_dq
-                # with action_if_failed (ignore, drop) and ignore(agg_dq)
-                # collect stats in the test_stats_table & error into error_table
-                spark.createDataFrame(
-                    [
-                        # count of distinct element in col2 must be greater than 2
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet expectation1(ignore)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets all row_dq expectations
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all row_dq expectations
-                    ]
-                ),
+            # Test case 22
+            # In this test case, dq run set for query_dq source_query_dq &
+            # final_query_dq(ignore, fail)
+            # with action_if_failed (ignore, fail) for query_dq
+            # collect stats in the test_stats_table, error into error_table & raise the error
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col1_threshold_1",
-                        "column_name": "col1",
-                        "expectation": "col1 > 1",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "col1 value must be greater than 1",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "10",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col2_set",
-                        "column_name": "col2",
-                        "expectation": "col2 in ('a', 'b', 'c')",
-                        "action_if_failed": "drop",
-                        "tag": "validity",
-                        "description": "col1 value must be greater than 2",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "10",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "agg_dq",
-                        "rule": "distinct_col2_threshold",
-                        "column_name": "col2",
-                        "expectation": "count(distinct col2) > 4",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "distinct of col2 value must be greater than 4",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                spark.createDataFrame(
-                    [  # expected_output
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),
-                3,  # input count
-                1,  # error count
-                3,  # output count
-                [
-                    {
-                        "description": "distinct of col2 value must be greater than 4",
-                        "rule": "distinct_col2_threshold",
-                        "rule_type": "agg_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                    }
-                ],
-                # source_agg_result
-                None,  # final_agg_result
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    # min of col1 must be greater than 10(ignore) - source_query_dq
+                    # max of col1 must be greater than 100(fail) - final_query_dq
+                    # min of col3 must be greater than 0(fail) - final_query_dq
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row meets all row_dq_expectations(drop)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # ow doesn't meet row_dq expectation1(drop)
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all row_dq_expectations
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 3, "num_row_dq_rules": 2},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 1,
-                        "num_agg_dq_rules": 1,
-                        "num_final_agg_dq_rules": 1,
-                    },
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "agg_dq",
+                    "rule": "col3_max_value",
+                    "column_name": "col3",
+                    "expectation": "max(col3) > 1",
+                    "action_if_failed": "fail",
+                    "tag": "validity",
+                    "description": "col3 mod must equals to 0",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "row_dq",
+                    "rule": "col3_mod_2",
+                    "column_name": "col3",
+                    "expectation": "(col3 % 2) = 0",
+                    "action_if_failed": "drop",
+                    "tag": "validity",
+                    "description": "col3 mod must equals to 0",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "100",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "count_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(select count(col1) from test_final_table_view) > 3",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                    "description": "count of col1 value must be greater than 3",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "col3_positive_threshold",
+                    "column_name": "col1",
+                    "expectation": "(select count(case when col3>0 then 1 else 0 end) from "
+                    "test_final_table_view) > 10",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                    "description": "count of col3 positive value must be greater than 10",
+                    "enable_for_source_dq_validation": False,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            True,  # write to table
+            False,  # write to temp table
+            spark.createDataFrame(
+                [
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),  # expected result
+            3,  # input count
+            1,  # error count
+            2,  # output count
+            None,  # source_agg_result
+            None,  # final_agg_result
+            # final_agg_result
+            [
+                {
+                    "description": "count of col1 value must be greater than 3",
+                    "rule": "count_col1_threshold",
+                    "rule_type": "query_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                }
+            ],
+            # source_query_dq_res
+            [
+                {
+                    "description": "count of col3 positive value must be greater than 10",
+                    "rule": "col3_positive_threshold",
+                    "rule_type": "query_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "strict",
+                }
+            ],
+            # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 1,
+                    "num_source_query_dq_rules": 1,
+                    "num_query_dq_rules": 2,
                 },  # dq_rules
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Passed",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
-                },  # status
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 1,
+                    "num_agg_dq_rules": 1,
+                    "num_final_agg_dq_rules": 1,
+                },
+            },
+            {
+                "row_dq_status": "Passed",
+                "source_agg_dq_status": "Passed",
+                "final_agg_dq_status": "Passed",
+                "run_status": "Passed",
+                "source_query_dq_status": "Passed",
+                "final_query_dq_status": "Passed",
+            },  # status
         ),
         (
-                # Test case 14
-                # In this test case, dq run set for row_dq, source_agg_dq & final_agg_dq
-                # with action_if_failed r(ignore, drop) for row_dq  and (ignore) for agg_dq
-                # collect stats in the test_stats_table & error into error_table
-                spark.createDataFrame(
-                    [
-                        # avg of col1 must be greater than 4(ignore) for agg_dq
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet row_dq expectation1(ignore)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row doesn't meet row_dq expectation2(drop)
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all row-dq expectations
-                    ]
-                ),
+            # Test case 23
+            # In this test case, dq run set for query_dq source_query_dq and one of the rule is parameterized
+            # with action_if_failed (ignore) for query_dq
+            # collect stats in the test_stats_table & error into error_table
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_threshold_4",
-                        "column_name": "col3",
-                        "expectation": "col3 > 4",
-                        "action_if_failed": "drop",
-                        "tag": "validity",
-                        "description": "col3 value must be greater than 4",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col2_set",
-                        "column_name": "col2",
-                        "expectation": "col2 in ('a', 'b')",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "col2 value must be in (a, b)",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "2",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "agg_dq",
-                        "rule": "avg_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "avg(col1) > 4",
-                        "action_if_failed": "ignore",
-                        "tag": "accuracy",
-                        "description": "avg of col1 value must be greater than 4",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                spark.createDataFrame(
-                    [  # expected_output
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),  # expected result
-                3,  # input count
-                2,  # error count
-                2,  # output count
-                [
-                    {
-                        "description": "avg of col1 value must be greater than 4",
-                        "rule": "avg_col1_threshold",
-                        "rule_type": "agg_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "accuracy",
-                    }
-                ],
-                # source_agg_dq
-                [
-                    {
-                        "description": "avg of col1 value must be greater than 4",
-                        "rule": "avg_col1_threshold",
-                        "rule_type": "agg_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "accuracy",
-                    }
-                ],
-                # final_agg_dq
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    # sum of col1 must be greater than 10(ignore)
+                    # standard deviation of col3 must be greater than 0(ignore)
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    # row doesn't meet row_dq expectation1(drop)
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    # row meets all row_dq_expectations
+                    {"col1": 3, "col2": "c", "col3": 6},
+                    # row meets all row_dq_expectations
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 3, "num_row_dq_rules": 2},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 1,
-                        "num_agg_dq_rules": 1,
-                        "num_final_agg_dq_rules": 1,
-                    },
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "sum_col1_threshold",
+                    "column_name": "col1",
+                    "expectation": "(select sum(col1) from {table}) > 10",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "sum of col1 value must be greater than 10",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+                {
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "query_dq",
+                    "rule": "stddev_col3_threshold",
+                    "column_name": "col3",
+                    "expectation": "(select stddev(col3) from test_table) > 0",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                    "description": "stddev of col3 value must be greater than 0",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": True,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                },
+            ],
+            False,  # write to table
+            False,  # write to temp table
+            None,  # expected result
+            3,  # input count
+            0,  # error count
+            0,  # output count
+            None,  # source_agg_result
+            None,  # final_agg_result
+            # final_agg_result
+            [
+                {
+                    "description": "sum of col1 value must be greater than 10",
+                    "rule": "sum_col1_threshold",
+                    "rule_type": "query_dq",
+                    "action_if_failed": "ignore",
+                    "tag": "validity",
+                }
+            ],
+            # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 2,
+                    "num_source_query_dq_rules": 2,
+                    "num_query_dq_rules": 2,
                 },  # dq_rules
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Passed",
-                    "final_agg_dq_status": "Passed",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
-                },  # status
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 0,
+                    "num_agg_dq_rules": 0,
+                    "num_final_agg_dq_rules": 0,
+                },
+            },
+            {
+                "row_dq_status": "Skipped",
+                "source_agg_dq_status": "Skipped",
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Passed",
+                "source_query_dq_status": "Passed",
+                "final_query_dq_status": "Skipped",
+            },  # status
         ),
         (
-                # Test case 15
-                # In this test case, dq run set for row_dq, source_agg_dq & final_agg_dq
-                # with action_if_failed (ignore, drop) for row_dq  and (ignore, fail) for agg_dq
-                # collect stats in the test_stats_table & error into error_table
-                spark.createDataFrame(
-                    [
-                        # average of col1 must be greater than 4(ignore)
-                        # standard deviation of col1 must be greater than 0(fail)
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets all row_dq_expectations
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all row_dq_expectations
-                        {"col1": 2, "col2": "d", "col3": 7},
-                    ]
-                ),
+            # Test case 24
+            # In this test case, dq run set for source_agg_dq with action_if_failed fail
+            # with the sql syntax > lower_bound and < upper_bound
+            # collect stats in the test_stats_table
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_and_col1_threshold_4",
-                        "column_name": "col3, col1",
-                        "expectation": "((col3 * col1) - col3) > 5",
-                        "action_if_failed": "drop",
-                        "tag": "validity",
-                        "description": "col3 and col1 operation value must be greater than 3",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "25",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col2_set",
-                        "column_name": "col2",
-                        "expectation": "col2 in ('b', 'c')",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "col2 value must be in (b, c)",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "30",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "agg_dq",
-                        "rule": "avg_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "avg(col1) > 4",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "avg of col1 value must be greater than 4",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "agg_dq",
-                        "rule": "stddev_col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "stddev(col3) > 1",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "stddev of col3 value must be greater than one",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                spark.createDataFrame(
-                    [  # expected_output
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        {"col1": 2, "col2": "d", "col3": 7},
-                    ]
-                ),  # expected result
-                4,  # input count
-                3,  # error count
-                2,  # output count
-                [
-                    {
-                        "description": "avg of col1 value must be greater than 4",
-                        "rule": "avg_col1_threshold",
-                        "rule_type": "agg_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                    }
-                ],
-                # source_agg_result
-                [
-                    {
-                        "action_if_failed": "ignore",
-                        "description": "avg of col1 value must be greater than 4",
-                        "rule": "avg_col1_threshold",
-                        "rule_type": "agg_dq",
-                        "tag": "validity",
-                    },
-                    {
-                        "action_if_failed": "ignore",
-                        "description": "stddev of col3 value must be greater than one",
-                        "rule": "stddev_col3_threshold",
-                        "rule_type": "agg_dq",
-                        "tag": "validity",
-                    },
-                ],
-                # final_agg_result
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
+                    # avg of col3 is greater than 18 and not more than 25
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 5, "num_row_dq_rules": 2},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },  # dq_rules
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 2,
-                        "num_agg_dq_rules": 3,
-                        "num_final_agg_dq_rules": 2,
-                    },
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "agg_dq",
+                    "rule": "avg_col3_range",
+                    "column_name": "col3",
+                    "expectation": "avg(col3) > 18 and avg(col3) < 25",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                    "description": "avg col3 value must be greater than 18 and less than 25",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                }
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            SparkExpectationsMiscException,  # excepted result
+            3,  # input count
+            0,  # error count
+            0,  # output count
+            [
+                {
+                    "description": "avg col3 value must be greater than 18 and less than 25",  # source_agg_result
+                    "rule": "avg_col3_range",
+                    "rule_type": "agg_dq",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                }
+            ],
+            None,  # final_agg_result
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
                 },
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Passed",
-                    "final_agg_dq_status": "Passed",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
-                },  # status
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 1,
+                    "num_agg_dq_rules": 1,
+                    "num_final_agg_dq_rules": 1,
+                },
+            },  # dq_rules
+            {
+                "row_dq_status": "Skipped",
+                "source_agg_dq_status": "Failed",  # status
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Failed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
         ),
         (
-                # Test case 16
-                # In this test case, dq run set for query_dq source_query_dq
-                # with action_if_failed (ignore) for query_dq
-                # collect stats in the test_stats_table & error into error_table
-                spark.createDataFrame(
-                    [
-                        # sum of col1 must be greater than 10(ignore)
-                        # standard deviation of col3 must be greater than 0(ignore)
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet row_dq expectation1(drop)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets all row_dq_expectations
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all row_dq_expectations
-                    ]
-                ),
+            # Test case 25
+            # In this test case, dq run set for source_agg_dq with action_if_failed fail
+            # with the sql syntax between lower_bound and upper_bound
+            # collect stats in the test_stats_table
+            spark.createDataFrame(
                 [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "sum_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(select sum(col1) from test_table) > 10",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "sum of col1 value must be greater than 10",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "stddev_col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "(select stddev(col3) from test_table) > 0",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "stddev of col3 value must be greater than 0",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                False,  # write to table
-                False,  # write to temp table
-                None,  # expected result
-                3,  # input count
-                0,  # error count
-                0,  # output count
-                None,  # source_agg_result
-                None,  # final_agg_result
-                # final_agg_result
-                [
-                    {
-                        "description": "sum of col1 value must be greater than 10",
-                        "rule": "sum_col1_threshold",
-                        "rule_type": "query_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                    }
-                ],
-                # source_query_dq_res
-                None,  # final_query_dq_res
+                    # avg of col3 is greater than 18 and not more than 25
+                    {"col1": 1, "col2": "a", "col3": 4},
+                    {"col1": 2, "col2": "b", "col3": 5},
+                    {"col1": 3, "col2": "c", "col3": 6},
+                ]
+            ),
+            [
                 {
-                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 2,
-                        "num_source_query_dq_rules": 2,
-                        "num_query_dq_rules": 2,
-                    },  # dq_rules
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
+                    "product_id": "product1",
+                    "table_name": "dq_spark.test_final_table",
+                    "rule_type": "agg_dq",
+                    "rule": "avg_col3_range",
+                    "column_name": "col3",
+                    "expectation": "avg(col3) between 18 and 25",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                    "description": "avg col3 value must be greater than 18 and less than 25",
+                    "enable_for_source_dq_validation": True,
+                    "enable_for_target_dq_validation": False,
+                    "is_active": True,
+                    "enable_error_drop_alert": False,
+                    "error_drop_threshold": "20",
+                }
+            ],
+            True,  # write to table
+            True,  # write to temp table
+            SparkExpectationsMiscException,  # excepted result
+            3,  # input count
+            0,  # error count
+            0,  # output count
+            [
+                {
+                    "description": "avg col3 value must be greater than 18 and less than 25",  # source_agg_result
+                    "rule": "avg_col3_range",
+                    "rule_type": "agg_dq",
+                    "action_if_failed": "fail",
+                    "tag": "strict",
+                }
+            ],
+            None,  # final_agg_result
+            None,  # source_query_dq_res
+            None,  # final_query_dq_res
+            {
+                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
+                "query_dq_rules": {
+                    "num_final_query_dq_rules": 0,
+                    "num_source_query_dq_rules": 0,
+                    "num_query_dq_rules": 0,
                 },
-                {
-                    "row_dq_status": "Skipped",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Passed",
-                    "final_query_dq_status": "Skipped",
-                },  # status
-        ),
-        (
-                # Test case 17
-                # In this test case, dq run set for query_dq final_query_dq
-                # with action_if_failed (ignore) for query_dq
-                # collect stats in the test_stats_table & error into error_table
-                spark.createDataFrame(
-                    [
-                        # max of col1 must be greater than 10(ignore)
-                        # min of col3 must be greater than 0(ignore)
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets all row_dq_expectations
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all row_dq_expectations
-                    ]
-                ),
-                [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_and_col1_threshold_4",
-                        "column_name": "col3, col1",
-                        "expectation": "((col3 * col1) - col3) > 5",
-                        "action_if_failed": "drop",
-                        "tag": "validity",
-                        "description": "col3 and col1 operation value must be greater than 3",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "max_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(select max(col1) from test_final_table_view) > 10",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                        "description": "max of col1 value must be greater than 10",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "min_col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "(select min(col3) from test_final_table_view) > 0",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "min of col3 value must be greater than 0",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                True,  # write to table
-                False,  # write to temp table
-                spark.createDataFrame(
-                    [
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),  # expected result
-                3,  # input count
-                2,  # error count
-                1,  # output count
-                None,  # source_agg_result
-                None,  # final_agg_result
-                # final_agg_result
-                None,  # source_query_dq_res
-                [
-                    {
-                        "description": "max of col1 value must be greater than 10",
-                        "rule": "max_col1_threshold",
-                        "rule_type": "query_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                    }
-                ],
-                # final_query_dq_res
-                {
-                    "rules": {"num_dq_rules": 3, "num_row_dq_rules": 1},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 2,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 2,
-                    },  # dq_rules
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
+                "agg_dq_rules": {
+                    "num_source_agg_dq_rules": 1,
+                    "num_agg_dq_rules": 1,
+                    "num_final_agg_dq_rules": 1,
                 },
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Passed",
-                },  # status
-        ),
-        (
-                # Test case 18
-                # In this test case, dq run set for query_dq source_query_dq(ignore, fail)
-                # with action_if_failed (fail) for query_dq
-                # collect stats in the test_stats_table, error into error_table & raises the error
-                spark.createDataFrame(
-                    [
-                        # min of col1 must be greater than 10(fail)
-                        # standard deviation of col3 must be greater than 0(ignore)
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet row_dq expectation1(drop)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets all row_dq_expectations
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all row_dq_expectations
-                    ]
-                ),
-                [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "min_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(select min(col1) from test_final_table_view) > 10",
-                        "action_if_failed": "fail",
-                        "tag": "validity",
-                        "description": "min of col1 value must be greater than 10",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "stddev_col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "(select stddev(col3) from test_final_table_view) > 0",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "stddev of col3 value must be greater than 0",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                False,  # write to table
-                False,  # write to temp table
-                SparkExpectationsMiscException,  # expected result
-                3,  # input count
-                0,  # error count
-                0,  # output count
-                None,  # source_agg_result
-                None,  # final_agg_result
-                [
-                    {
-                        "action_if_failed": "fail",
-                        "description": "min of col1 value must be greater than 10",
-                        "rule": "min_col1_threshold",
-                        "rule_type": "query_dq",
-                        "tag": "validity",
-                    },
-                    {
-                        "action_if_failed": "ignore",
-                        "description": "stddev of col3 value must be greater than 0",
-                        "rule": "stddev_col3_threshold",
-                        "rule_type": "query_dq",
-                        "tag": "validity",
-                    },
-                ],  # source_query_dq_res
-                None,  # final_query_dq_res
-                {
-                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 2,
-                        "num_source_query_dq_rules": 2,
-                        "num_query_dq_rules": 2,
-                    },  # dq_rules
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
-                },
-                {
-                    "row_dq_status": "Skipped",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Failed",
-                    "source_query_dq_status": "Failed",
-                    "final_query_dq_status": "Skipped",
-                },  # status
-        ),
-        (
-                # Test case 19
-                # In this test case, dq run set for query_dq final_query_dq(ignore, fail)
-                # with action_if_failed (ignore, fail) for query_dq
-                # collect stats in the test_stats_table, error into error_table & raises error
-                spark.createDataFrame(
-                    [
-                        # max of col1 must be greater than 10(ignore)
-                        # min of col3 must be greater than 0(ignore)
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets all row_dq_expectations
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all row_dq_expectations
-                    ]
-                ),
-                [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_and_col1_threshold_4",
-                        "column_name": "col3, col1",
-                        "expectation": "((col3 * col1) - col3) > 5",
-                        "action_if_failed": "drop",
-                        "tag": "validity",
-                        "description": "col3 and col1 operation value must be greater than 3",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "25",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "max_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(select max(col1) from test_final_table_view) > 10",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                        "description": "max of col1 value must be greater than 10",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "min_col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "(select min(col3) from test_final_table_view) > 0",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "min of col3 value must be greater than 0",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                True,  # write to table
-                False,  # write to temp table
-                SparkExpectationsMiscException,  # expected result
-                3,  # input count
-                2,  # error count
-                1,  # output count
-                None,  # source_agg_result
-                None,  # final_agg_result
-                # final_agg_result
-                None,  # source_query_dq_res
-                [
-                    {
-                        "description": "max of col1 value must be greater than 10",
-                        "rule": "max_col1_threshold",
-                        "rule_type": "query_dq",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                    }
-                ],
-                # final_query_dq_res
-                {
-                    "rules": {"num_dq_rules": 3, "num_row_dq_rules": 1},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 2,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 2,
-                    },  # dq_rules
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
-                },
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Failed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Failed",
-                },  # status
-        ),
-        (
-                # Test case 20
-                # In this test case, dq run set for query_dq source_query_dq &
-                # final_query_dq(ignore, fail)
-                # with action_if_failed (ignore, fail) for query_dq
-                # collect stats in the test_stats_table, error into error_table
-                spark.createDataFrame(
-                    [
-                        # min of col1 must be greater than 10(ignore) - source_query_dq
-                        # max of col1 must be greater than 100(ignore) - final_query_dq
-                        # min of col3 must be greater than 0(fail) - final_query_dq
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row meets all row_dq_expectations(drop)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # ow doesn't meet row_dq expectation1(drop)
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all row_dq_expectations
-                    ]
-                ),
-                [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_mod_2",
-                        "column_name": "col3",
-                        "expectation": "(col3 % 2) = 0",
-                        "action_if_failed": "drop",
-                        "tag": "validity",
-                        "description": "col3 mod must equals to 0",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": True,
-                        "error_drop_threshold": "40",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "min_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(select min(col1) from test_final_table_view) > 10",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                        "description": "min of col1 value must be greater than 10",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "max_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(select max(col1) from test_final_table_view) > 100",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                        "description": "max of col1 value must be greater than 100",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "min_col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "(select min(col3) from test_final_table_view) > 0",
-                        "action_if_failed": "fail",
-                        "tag": "validity",
-                        "description": "min of col3 value must be greater than 0",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                True,  # write to table
-                False,  # write to temp table
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),  # expected result
-                3,  # input count
-                1,  # error count
-                2,  # output count
-                None,  # source_agg_result
-                None,  # final_agg_result
-                # final_agg_result
-                [
-                    {
-                        "description": "min of col1 value must be greater than 10",
-                        "rule": "min_col1_threshold",
-                        "rule_type": "query_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                    }
-                ],
-                # source_query_dq_res
-                [
-                    {
-                        "description": "max of col1 value must be greater than 100",
-                        "rule": "max_col1_threshold",
-                        "rule_type": "query_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                    }
-                ],
-                # final_query_dq_res
-                {
-                    "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 2,
-                        "num_source_query_dq_rules": 1,
-                        "num_query_dq_rules": 3,
-                    },  # dq_rules
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
-                },
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Passed",
-                    "final_query_dq_status": "Passed",
-                },  # status
-        ),
-        (
-                # Test case 21
-                # In this test case, dq run set for query_dq source_query_dq &
-                # final_query_dq(ignore, fail)
-                # with action_if_failed (ignore, fail) for query_dq
-                # collect stats in the test_stats_table, error into error_table & raise the error
-                spark.createDataFrame(
-                    [
-                        # min of col1 must be greater than 10(ignore) - source_query_dq
-                        # max of col1 must be greater than 100(fail) - final_query_dq
-                        # min of col3 must be greater than 0(fail) - final_query_dq
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row meets all row_dq_expectations(drop)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # ow doesn't meet row_dq expectation1(drop)
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all row_dq_expectations
-                    ]
-                ),
-                [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_mod_2",
-                        "column_name": "col3",
-                        "expectation": "(col3 % 2) = 0",
-                        "action_if_failed": "drop",
-                        "tag": "validity",
-                        "description": "col3 mod must equals to 0",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "10",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "min_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(select min(col1) from test_final_table_view) > 10",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                        "description": "min of col1 value must be greater than 10",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "max_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(select max(col1) from test_final_table_view) > 100",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                        "description": "max of col1 value must be greater than 100",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "min_col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "(select min(col3) from test_final_table_view) > 0",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "min of col3 value must be greater than 0",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                True,  # write to table
-                False,  # write to temp table
-                SparkExpectationsMiscException,  # expected result
-                3,  # input count
-                1,  # error count
-                2,  # output count
-                None,  # source_agg_result
-                None,  # final_agg_result
-                # final_agg_result
-                [
-                    {
-                        "description": "min of col1 value must be greater than 10",
-                        "rule": "min_col1_threshold",
-                        "rule_type": "query_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                    }
-                ],
-                # source_query_dq_res
-                [
-                    {
-                        "description": "max of col1 value must be greater than 100",
-                        "rule": "max_col1_threshold",
-                        "rule_type": "query_dq",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                    }
-                ],
-                # final_query_dq_res
-                {
-                    "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 2,
-                        "num_source_query_dq_rules": 1,
-                        "num_query_dq_rules": 3,
-                    },  # dq_rules
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
-                },
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Failed",
-                    "source_query_dq_status": "Passed",
-                    "final_query_dq_status": "Failed",
-                },  # status
-        ),
-        (
-                # Test case 22
-                # In this test case, dq run set for query_dq source_query_dq &
-                # final_query_dq(ignore, fail)
-                # with action_if_failed (ignore, fail) for query_dq
-                # collect stats in the test_stats_table, error into error_table & raise the error
-                spark.createDataFrame(
-                    [
-                        # min of col1 must be greater than 10(ignore) - source_query_dq
-                        # max of col1 must be greater than 100(fail) - final_query_dq
-                        # min of col3 must be greater than 0(fail) - final_query_dq
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row meets all row_dq_expectations(drop)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # ow doesn't meet row_dq expectation1(drop)
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all row_dq_expectations
-                    ]
-                ),
-                [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "agg_dq",
-                        "rule": "col3_max_value",
-                        "column_name": "col3",
-                        "expectation": "max(col3) > 1",
-                        "action_if_failed": "fail",
-                        "tag": "validity",
-                        "description": "col3 mod must equals to 0",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "row_dq",
-                        "rule": "col3_mod_2",
-                        "column_name": "col3",
-                        "expectation": "(col3 % 2) = 0",
-                        "action_if_failed": "drop",
-                        "tag": "validity",
-                        "description": "col3 mod must equals to 0",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "100",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "count_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(select count(col1) from test_final_table_view) > 3",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                        "description": "count of col1 value must be greater than 3",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "col3_positive_threshold",
-                        "column_name": "col1",
-                        "expectation": "(select count(case when col3>0 then 1 else 0 end) from "
-                                       "test_final_table_view) > 10",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                        "description": "count of col3 positive value must be greater than 10",
-                        "enable_for_source_dq_validation": False,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                True,  # write to table
-                False,  # write to temp table
-                spark.createDataFrame(
-                    [
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),  # expected result
-                3,  # input count
-                1,  # error count
-                2,  # output count
-                None,  # source_agg_result
-                None,  # final_agg_result
-                # final_agg_result
-                [
-                    {
-                        "description": "count of col1 value must be greater than 3",
-                        "rule": "count_col1_threshold",
-                        "rule_type": "query_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                    }
-                ],
-                # source_query_dq_res
-                [
-                    {
-                        "description": "count of col3 positive value must be greater than 10",
-                        "rule": "col3_positive_threshold",
-                        "rule_type": "query_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "strict",
-                    }
-                ],
-                # final_query_dq_res
-                {
-                    "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 1,
-                        "num_source_query_dq_rules": 1,
-                        "num_query_dq_rules": 2,
-                    },  # dq_rules
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 1,
-                        "num_agg_dq_rules": 1,
-                        "num_final_agg_dq_rules": 1,
-                    },
-                },
-                {
-                    "row_dq_status": "Passed",
-                    "source_agg_dq_status": "Passed",
-                    "final_agg_dq_status": "Passed",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Passed",
-                    "final_query_dq_status": "Passed",
-                },  # status
-        ),
-        (
-                # Test case 23
-                # In this test case, dq run set for query_dq source_query_dq and one of the rule is parameterized
-                # with action_if_failed (ignore) for query_dq
-                # collect stats in the test_stats_table & error into error_table
-                spark.createDataFrame(
-                    [
-                        # sum of col1 must be greater than 10(ignore)
-                        # standard deviation of col3 must be greater than 0(ignore)
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        # row doesn't meet row_dq expectation1(drop)
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        # row meets all row_dq_expectations
-                        {"col1": 3, "col2": "c", "col3": 6},
-                        # row meets all row_dq_expectations
-                    ]
-                ),
-                [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "sum_col1_threshold",
-                        "column_name": "col1",
-                        "expectation": "(select sum(col1) from {table}) > 10",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "sum of col1 value must be greater than 10",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "query_dq",
-                        "rule": "stddev_col3_threshold",
-                        "column_name": "col3",
-                        "expectation": "(select stddev(col3) from test_table) > 0",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                        "description": "stddev of col3 value must be greater than 0",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": True,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    },
-                ],
-                False,  # write to table
-                False,  # write to temp table
-                None,  # expected result
-                3,  # input count
-                0,  # error count
-                0,  # output count
-                None,  # source_agg_result
-                None,  # final_agg_result
-                # final_agg_result
-                [
-                    {
-                        "description": "sum of col1 value must be greater than 10",
-                        "rule": "sum_col1_threshold",
-                        "rule_type": "query_dq",
-                        "action_if_failed": "ignore",
-                        "tag": "validity",
-                    }
-                ],
-                # source_query_dq_res
-                None,  # final_query_dq_res
-                {
-                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 2,
-                        "num_source_query_dq_rules": 2,
-                        "num_query_dq_rules": 2,
-                    },  # dq_rules
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 0,
-                        "num_agg_dq_rules": 0,
-                        "num_final_agg_dq_rules": 0,
-                    },
-                },
-                {
-                    "row_dq_status": "Skipped",
-                    "source_agg_dq_status": "Skipped",
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Passed",
-                    "source_query_dq_status": "Passed",
-                    "final_query_dq_status": "Skipped",
-                },  # status
-        ),
-        (
-                # Test case 24
-                # In this test case, dq run set for source_agg_dq with action_if_failed fail
-                # with the sql syntax > lower_bound and < upper_bound
-                # collect stats in the test_stats_table
-                spark.createDataFrame(
-                    [
-                        # avg of col3 is greater than 18 and not more than 25
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),
-                [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "agg_dq",
-                        "rule": "avg_col3_range",
-                        "column_name": "col3",
-                        "expectation": "avg(col3) > 18 and avg(col3) < 25",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                        "description": "avg col3 value must be greater than 18 and less than 25",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    }
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                SparkExpectationsMiscException,  # excepted result
-                3,  # input count
-                0,  # error count
-                0,  # output count
-                [
-                    {
-                        "description": "avg col3 value must be greater than 18 and less than 25",  # source_agg_result
-                        "rule": "avg_col3_range",
-                        "rule_type": "agg_dq",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                    }
-                ],
-                None,  # final_agg_result
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
-                {
-                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 1,
-                        "num_agg_dq_rules": 1,
-                        "num_final_agg_dq_rules": 1,
-                    },
-                },  # dq_rules
-                {
-                    "row_dq_status": "Skipped",
-                    "source_agg_dq_status": "Failed",  # status
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Failed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
-                },
-        ),
-        (
-                # Test case 25
-                # In this test case, dq run set for source_agg_dq with action_if_failed fail
-                # with the sql syntax between lower_bound and upper_bound
-                # collect stats in the test_stats_table
-                spark.createDataFrame(
-                    [
-                        # avg of col3 is greater than 18 and not more than 25
-                        {"col1": 1, "col2": "a", "col3": 4},
-                        {"col1": 2, "col2": "b", "col3": 5},
-                        {"col1": 3, "col2": "c", "col3": 6},
-                    ]
-                ),
-                [
-                    {
-                        "product_id": "product1",
-                        "table_name": "dq_spark.test_final_table",
-                        "rule_type": "agg_dq",
-                        "rule": "avg_col3_range",
-                        "column_name": "col3",
-                        "expectation": "avg(col3) between 18 and 25",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                        "description": "avg col3 value must be greater than 18 and less than 25",
-                        "enable_for_source_dq_validation": True,
-                        "enable_for_target_dq_validation": False,
-                        "is_active": True,
-                        "enable_error_drop_alert": False,
-                        "error_drop_threshold": "20",
-                    }
-                ],
-                True,  # write to table
-                True,  # write to temp table
-                SparkExpectationsMiscException,  # excepted result
-                3,  # input count
-                0,  # error count
-                0,  # output count
-                [
-                    {
-                        "description": "avg col3 value must be greater than 18 and less than 25",  # source_agg_result
-                        "rule": "avg_col3_range",
-                        "rule_type": "agg_dq",
-                        "action_if_failed": "fail",
-                        "tag": "strict",
-                    }
-                ],
-                None,  # final_agg_result
-                None,  # source_query_dq_res
-                None,  # final_query_dq_res
-                {
-                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
-                    "query_dq_rules": {
-                        "num_final_query_dq_rules": 0,
-                        "num_source_query_dq_rules": 0,
-                        "num_query_dq_rules": 0,
-                    },
-                    "agg_dq_rules": {
-                        "num_source_agg_dq_rules": 1,
-                        "num_agg_dq_rules": 1,
-                        "num_final_agg_dq_rules": 1,
-                    },
-                },  # dq_rules
-                {
-                    "row_dq_status": "Skipped",
-                    "source_agg_dq_status": "Failed",  # status
-                    "final_agg_dq_status": "Skipped",
-                    "run_status": "Failed",
-                    "source_query_dq_status": "Skipped",
-                    "final_query_dq_status": "Skipped",
-                },
+            },  # dq_rules
+            {
+                "row_dq_status": "Skipped",
+                "source_agg_dq_status": "Failed",  # status
+                "final_agg_dq_status": "Skipped",
+                "run_status": "Failed",
+                "source_query_dq_status": "Skipped",
+                "final_query_dq_status": "Skipped",
+            },
         ),
     ],
 )
 def test_with_expectations(
-        input_df,
-        expectations,
-        write_to_table,
-        write_to_temp_table,
-        expected_output,
-        input_count,
-        error_count,
-        output_count,
-        source_agg_dq_res,
-        final_agg_dq_res,
-        source_query_dq_res,
-        final_query_dq_res,
-        dq_rules,
-        status,
-        _fixture_create_database,
-        _fixture_local_kafka_topic,
+    input_df,
+    expectations,
+    write_to_table,
+    write_to_temp_table,
+    expected_output,
+    input_count,
+    error_count,
+    output_count,
+    source_agg_dq_res,
+    final_agg_dq_res,
+    source_query_dq_res,
+    final_query_dq_res,
+    dq_rules,
+    status,
+    _fixture_create_database,
+    _fixture_local_kafka_topic,
 ):
     input_df.createOrReplaceTempView("test_table")
 
@@ -2849,14 +2849,14 @@ def test_with_expectations(
 
     if isinstance(expected_output, type) and issubclass(expected_output, Exception):
         with pytest.raises(
-                expected_output,
-                match=r"error occurred while processing spark expectations .*",
+            expected_output,
+            match=r"error occurred while processing spark expectations .*",
         ):
             get_dataset()  # decorated_func()
 
         if (
-                status.get("final_agg_dq_status") == "Failed"
-                or status.get("final_query_dq_status") == "Failed"
+            status.get("final_agg_dq_status") == "Failed"
+            or status.get("final_query_dq_status") == "Failed"
         ):
             try:
                 spark.table("dq_spark.test_final_table")
@@ -2874,8 +2874,8 @@ def test_with_expectations(
 
             result_df = spark.table("dq_spark.test_final_table")
             assert (
-                    result_df.orderBy("col2").collect()
-                    == expected_output_df.orderBy("col2").collect()
+                result_df.orderBy("col2").collect()
+                == expected_output_df.orderBy("col2").collect()
             )
 
             if spark.catalog.tableExists("dq_spark.test_final_table_error"):
@@ -2906,17 +2906,17 @@ def test_with_expectations(
     assert len(stats_table.columns) == 20
 
     assert (
-            spark.read.format("kafka")
-            .option("kafka.bootstrap.servers", "localhost:9092")
-            .option("subscribe", "dq-sparkexpectations-stats")
-            .option("startingOffsets", "earliest")
-            .option("endingOffsets", "latest")
-            .load()
-            .orderBy(col("timestamp").desc())
-            .limit(1)
-            .selectExpr("cast(value as string) as value")
-            .collect()
-            == stats_table.selectExpr("to_json(struct(*)) AS value").collect()
+        spark.read.format("kafka")
+        .option("kafka.bootstrap.servers", "localhost:9092")
+        .option("subscribe", "dq-sparkexpectations-stats")
+        .option("startingOffsets", "earliest")
+        .option("endingOffsets", "latest")
+        .load()
+        .orderBy(col("timestamp").desc())
+        .limit(1)
+        .selectExpr("cast(value as string) as value")
+        .collect()
+        == stats_table.selectExpr("to_json(struct(*)) AS value").collect()
     )
 
     # spark.sql("select * from dq_spark.test_final_table").show(truncate=False)
@@ -2933,11 +2933,11 @@ def test_with_expectations(
 
 @patch("spark_expectations.core.expectations.SparkExpectationsWriter.write_error_stats")
 def test_with_expectations_patch(
-        _write_error_stats,
-        _fixture_create_database,
-        _fixture_spark_expectations,
-        _fixture_df,
-        _fixture_rules_df,
+    _write_error_stats,
+    _fixture_create_database,
+    _fixture_spark_expectations,
+    _fixture_df,
+    _fixture_rules_df,
 ):
     decorated_func = _fixture_spark_expectations.with_expectations(
         "dq_spark.test_final_table",
@@ -2954,10 +2954,10 @@ def test_with_expectations_patch(
 
 
 def test_with_expectations_overwrite_writers(
-        _fixture_create_database,
-        _fixture_spark_expectations,
-        _fixture_df,
-        _fixture_rules_df,
+    _fixture_create_database,
+    _fixture_spark_expectations,
+    _fixture_df,
+    _fixture_rules_df,
 ):
     modified_writer = WrappedDataFrameWriter().mode("overwrite").format("iceberg")
     _fixture_spark_expectations.with_expectations(
@@ -2967,17 +2967,17 @@ def test_with_expectations_overwrite_writers(
     )(Mock(return_value=_fixture_df))
 
     assert (
-            _fixture_spark_expectations._context.get_target_and_error_table_writer_config
-            == modified_writer.build()
+        _fixture_spark_expectations._context.get_target_and_error_table_writer_config
+        == modified_writer.build()
     )
 
 
 def test_with_expectations_dataframe_not_returned_exception(
-        _fixture_create_database,
-        _fixture_spark_expectations,
-        _fixture_df,
-        _fixture_rules_df,
-        _fixture_local_kafka_topic,
+    _fixture_create_database,
+    _fixture_spark_expectations,
+    _fixture_df,
+    _fixture_rules_df,
+    _fixture_local_kafka_topic,
 ):
     partial_func = _fixture_spark_expectations.with_expectations(
         "dq_spark.test_final_table",
@@ -2985,10 +2985,10 @@ def test_with_expectations_dataframe_not_returned_exception(
     )
 
     with pytest.raises(
-            SparkExpectationsMiscException,
-            match=r"error occurred while processing spark expectations error occurred while"
-                  r" processing spark "
-                  r"expectations due to given dataframe is not type of dataframe",
+        SparkExpectationsMiscException,
+        match=r"error occurred while processing spark expectations error occurred while"
+        r" processing spark "
+        r"expectations due to given dataframe is not type of dataframe",
     ):
         # Create a mock object with a rdd return value
         mock_func = Mock(return_value=_fixture_df.rdd)
@@ -3003,7 +3003,7 @@ def test_with_expectations_dataframe_not_returned_exception(
 
 
 def test_with_expectations_exception(
-        _fixture_create_database, _fixture_spark_expectations, _fixture_local_kafka_topic
+    _fixture_create_database, _fixture_spark_expectations, _fixture_local_kafka_topic
 ):
     rules_dict = [
         {
@@ -3040,8 +3040,8 @@ def test_with_expectations_exception(
     )
 
     with pytest.raises(
-            SparkExpectationsMiscException,
-            match=r"error occurred while processing spark expectations .*",
+        SparkExpectationsMiscException,
+        match=r"error occurred while processing spark expectations .*",
     ):
         # Create a mock object with a list return value
         mock_func = Mock(return_value=["apple", "banana", "pineapple", "orange"])
@@ -3057,7 +3057,7 @@ def test_with_expectations_exception(
 
 
 def test_with_expectations_negative_parameter(
-        _fixture_create_database, _fixture_spark_expectations, _fixture_local_kafka_topic
+    _fixture_create_database, _fixture_spark_expectations, _fixture_local_kafka_topic
 ):
     rules_dict = [
         {
@@ -3094,8 +3094,8 @@ def test_with_expectations_negative_parameter(
     )
 
     with pytest.raises(
-            SparkExpectationsMiscException,
-            match=r"error occurred while retrieving rules list from the table 'table2'",
+        SparkExpectationsMiscException,
+        match=r"error occurred while retrieving rules list from the table 'table2'",
     ):
         # Create a mock object with a list return value
         mock_func = Mock(return_value=["apple", "banana", "pineapple", "orange"])
@@ -3115,9 +3115,9 @@ def test_with_expectations_negative_parameter(
 # @patch('spark_expectations.notifications.push.spark_expectations_notify._notification_hook', autospec=True,
 #        spec_set=True)
 def test_error_threshold_breach(
-        # _mock_notification_hook, _mock_spark_expectations_notify,
-        _fixture_create_database,
-        _fixture_local_kafka_topic,
+    # _mock_notification_hook, _mock_spark_expectations_notify,
+    _fixture_create_database,
+    _fixture_local_kafka_topic,
 ):
     input_df = spark.createDataFrame(
         [
@@ -3168,10 +3168,10 @@ def test_error_threshold_breach(
     writer = WrappedDataFrameWriter().mode("append").format("delta")
 
     with patch(
-            "spark_expectations.notifications.push.spark_expectations_notify.SparkExpectationsNotify"
-            ".notify_on_exceeds_of_error_threshold",
-            autospec=True,
-            spec_set=True,
+        "spark_expectations.notifications.push.spark_expectations_notify.SparkExpectationsNotify"
+        ".notify_on_exceeds_of_error_threshold",
+        autospec=True,
+        spec_set=True,
     ) as _mock_notification_hook:
         se = SparkExpectations(
             product_id="product1",
@@ -3208,7 +3208,7 @@ def test_error_threshold_breach(
 
 
 def test_target_table_view_exception(
-        _fixture_create_database, _fixture_local_kafka_topic
+    _fixture_create_database, _fixture_local_kafka_topic
 ):
     rules = [
         {
@@ -3282,8 +3282,8 @@ def test_target_table_view_exception(
         return input_df
 
     with pytest.raises(
-            SparkExpectationsMiscException,
-            match=r"error occurred while processing spark expectations .*",
+        SparkExpectationsMiscException,
+        match=r"error occurred while processing spark expectations .*",
     ):
         get_dataset()  # decorated_func()
 
@@ -3296,7 +3296,7 @@ def test_target_table_view_exception(
 def test_spark_expectations_exception():
     writer = WrappedDataFrameWriter().mode("append").format("parquet")
     with pytest.raises(
-            SparkExpectationsMiscException, match=r"Input rules_df is not of dataframe type"
+        SparkExpectationsMiscException, match=r"Input rules_df is not of dataframe type"
     ):
         SparkExpectations(
             product_id="product1",
@@ -3400,7 +3400,7 @@ def test_delta_bucketby_exception():
         WrappedDataFrameWriter().mode("append").format("delta").bucketBy(10, "a", "b")
     )
     with pytest.raises(
-            SparkExpectationsMiscException,
-            match=r"Bucketing is not supported for delta tables yet",
+        SparkExpectationsMiscException,
+        match=r"Bucketing is not supported for delta tables yet",
     ):
         writer.build()

--- a/tests/core/test_expectations.py
+++ b/tests/core/test_expectations.py
@@ -5,6 +5,13 @@ from unittest.mock import Mock, PropertyMock
 from unittest.mock import patch
 import pytest
 from pyspark.sql import DataFrame, SparkSession
+
+
+try:
+    from pyspark.sql.connect.dataframe import DataFrame as connectDataFrame
+except ImportError:
+    pass
+
 from pyspark.sql.functions import lit, to_timestamp, col
 from pyspark.sql.types import StringType, IntegerType, StructField, StructType
 
@@ -27,8 +34,8 @@ def fixture_setup_local_kafka_topic():
     current_dir = os.path.dirname(os.path.abspath(__file__))
 
     if (
-        os.getenv("UNIT_TESTING_ENV")
-        != "spark_expectations_unit_testing_on_github_actions"
+            os.getenv("UNIT_TESTING_ENV")
+            != "spark_expectations_unit_testing_on_github_actions"
     ):
         # remove if docker conatiner is running
         os.system(
@@ -207,7 +214,7 @@ def fixture_spark_expectations(_fixture_rules_df):
 def test_spark_session_initialization():
     # Test if spark session is initialized even if dataframe.sparkSession is not accessible
     with patch.object(
-        DataFrame, "sparkSession", new_callable=PropertyMock
+            DataFrame, "sparkSession", new_callable=PropertyMock
     ) as mock_sparkSession:
         mock_sparkSession.side_effect = AttributeError(
             "The 'sparkSession' attribute is not accessible"
@@ -228,7 +235,7 @@ def test_spark_session_initialization():
 
     # Test if exception is raised if sparkSession.getActiveSession() returns None
     with patch.object(
-        DataFrame, "sparkSession", new_callable=PropertyMock
+            DataFrame, "sparkSession", new_callable=PropertyMock
     ) as mock_sparkSession:
         mock_sparkSession.side_effect = AttributeError(
             "The 'sparkSession' attribute is not accessible"
@@ -250,8 +257,8 @@ def test_spark_session_initialization():
                 )
                 assert se.spark is None
                 assert (
-                    str(e.value)
-                    == "Spark session is not available, please initialize a spark session before calling SE"
+                        str(e.value)
+                        == "Spark session is not available, please initialize a spark session before calling SE"
                 )
 
 
@@ -272,2533 +279,2533 @@ def test_spark_session_initialization():
     "status",
     [
         (
-            # Note: where err: refers error table and fnl: final table
-            # test case 0
-            # In this test case, the action for failed rows is "ignore",
-            # so the function should return the input DataFrame with all rows.
-            # collect stats in the test_stats_table and
-            # log the error records into the error table.
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a"},
-                    # row doesn't meet expectations(ignore), log into err & fnl
-                    {"col1": 2, "col2": "b"},
-                    # row meets expectations(ignore), log into final table
-                    {"col1": 3, "col2": "c"},
-                    # row meets expectations(ignore), log into final table
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "col1 > 1",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "col1 value must be greater than 1",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "10",
-                }
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            # expected res
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a"},
-                    {"col1": 2, "col2": "b"},
-                    {"col1": 3, "col2": "c"},
-                ]
-            ),
-            3,  # input count
-            1,  # error count
-            3,  # output count
-            None,  # source_agg_dq_res
-            None,  # final_agg_dq_res
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
-                },
-            },  # dq_rules
-            # status at different stages for given input
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-        ),
-        (
-            # test case 1
-            # In this test case, the action for failed rows is "drop",
-            # collect stats in the test_stats_table and
-            # log the error records into the error table.
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row  meets expectations(drop), log into err & fnl
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row doesn't meets expectations(drop), log into final table
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets expectations(drop), log into final table
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col2_set",
-                    "column_name": "col2",
-                    "expectation": "col2 in  ('a', 'c')",
-                    "action_if_failed": "drop",
-                    "tag": "strict",
-                    "description": "col2 value must be in ('a', 'b')",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "5",
-                }
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            # expected res
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet expectations(ignore), log into err & fnl
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets expectations(ignore), log into final table
-                ]
-            ),
-            3,  # input count
-            1,  # error count
-            2,  # output count
-            None,  # source_agg_dq_res
-            None,  # final_agg_dq_res
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
-                },
-            },  # dq_rules
-            # status at different stages for given input
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-        ),
-        (
-            # test case 2
-            # In this test case, the action for failed rows is "fail",
-            # spark expectations expected to fail
-            # collect stats in the test_stats_table and
-            # log the error records into the error table.
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet expectations(fail), log into err & fnl
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets doesn't expectations(fail), log into final table
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets doesn't expectations(fail), log into final table
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "col3 > 6",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                    "description": "col3 value must be greater than 6",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "15",
-                }
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            SparkExpectationsMiscException,  # expected res
-            3,  # input count
-            3,  # error count
-            0,  # output count
-            None,  # source_agg_dq_res
-            None,  # final_agg_dq_res
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
-                },
-            },  # dq_rules
-            # status at different stages for given input
-            {
-                "row_dq_status": "Failed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Failed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-        ),
-        (  # test case 3
-            # In this test case, the action for failed rows is "ignore" & "drop",
-            # collect stats in the test_stats_table and
-            # log the error records into the error table.
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet expectations1(ignore) 2(drop), log into err & fnl
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets expectations1(ignore), log into final table
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row doesnt'meets expectations1(ignore), log into final table
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "col3 > 6",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                    "description": "col3 value must be greater than 6",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "10",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col1_add_col3_threshold",
-                    "column_name": "col1",
-                    "expectation": "(col1+col3) > 6",
-                    "action_if_failed": "drop",
-                    "tag": "strict",
-                    "description": "col1_add_col3 value must be greater than 6",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "15",
-                },
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            # expected res
-            spark.createDataFrame(
-                [
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),
-            3,  # input count
-            3,  # error count
-            2,  # output count
-            None,  # source_agg_dq_res
-            None,  # final_agg_dq_res
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
-                },
-            },  # dq_rules
-            # status at different stages for given input
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-        ),
-        (
-            # test case 4
-            # In this test case, the action for failed rows is "ignore" & "fail",
-            # collect stats in the test_stats_table and
-            # log the error records into the error table.
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet expectations1(ignore), log into err & fnl
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets expectations1(ignore), log into final table
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets expectations1(ignore), log into final table
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "col3 > 6",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                    "description": "col3 value must be greater than 6",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_minus_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(col3-col1) > 1",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                    "description": "col3_minus_col1 value must be greater than 1",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "5",
-                },
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            # expected res
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),
-            3,  # input count
-            3,  # error count
-            3,  # output count
-            None,  # source_agg_dq_res
-            None,  # final_agg_dq_res
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
-                },
-            },  # dq_rules
-            # status at different stages for given input
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-        ),
-        (
-            # Test case 5
-            # In this test case, the action for failed rows is "drop" & "fail",
-            # collect stats in the test_stats_table and
-            # log the error records into the error table.
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet expectations1(drop) & 2(drop), log into err & fnl
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets expectations1(drop) & 2(fail), log into final table
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets expectations1(drop), & 2(fail) log into final table
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "col3 > 6",
-                    "action_if_failed": "drop",
-                    "tag": "strict",
-                    "description": "col3 value must be greater than 6",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "25",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_minus_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(col3-col1) = 1",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                    "description": "col3_minus_col1 value must be equals to 1",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "25",
-                },
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            SparkExpectationsMiscException,  # expected res
-            3,  # input count
-            3,  # error count
-            0,  # output count
-            None,  # source_agg_dq_res
-            None,  # final_agg_dq_res
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
-                },
-            },  # dq_rules
-            # status at different stages for given input
-            {
-                "row_dq_status": "Failed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Failed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-        ),
-        (  # Test case 6
-            # In this test case, the action for failed rows is "drop" & "fail",
-            # collect stats in the test_stats_table and
-            # log the error records into the error table
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet expectations1(drop) & meets 2(fail), log into err & fnl
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets expectations1(drop) & meets 2(fail), log into final table
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets expectations1(drop) & meets 2(fail), log into final table
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "col3 > 6",
-                    "action_if_failed": "drop",
-                    "tag": "strict",
-                    "description": "col3 value must be greater than 6",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "10",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_mul_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(col3*col1) > 1",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                    "description": "col3_mul_col1 value must be equals to 1",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "10",
-                },
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            # expected res
-            spark.createDataFrame(
-                [],
-                schema=StructType(
+                # Note: where err: refers error table and fnl: final table
+                # test case 0
+                # In this test case, the action for failed rows is "ignore",
+                # so the function should return the input DataFrame with all rows.
+                # collect stats in the test_stats_table and
+                # log the error records into the error table.
+                spark.createDataFrame(
                     [
-                        StructField("col1", IntegerType()),
-                        StructField("col2", StringType()),
-                        StructField("col3", IntegerType()),
+                        {"col1": 1, "col2": "a"},
+                        # row doesn't meet expectations(ignore), log into err & fnl
+                        {"col1": 2, "col2": "b"},
+                        # row meets expectations(ignore), log into final table
+                        {"col1": 3, "col2": "c"},
+                        # row meets expectations(ignore), log into final table
                     ]
                 ),
-            ),
-            3,  # input count
-            3,  # error count
-            0,  # output count
-            None,  # source_agg_dq_res
-            None,  # final_agg_dq_res
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
-                },
-            },  # dq_rules
-            # status at different stages for given input
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-        ),
-        (
-            # Test case 7
-            # In this test case, the action for failed rows is "ignore", "drop" & "fail",
-            # collect stats in the test_stats_table and
-            # log the error records into the error table
-            spark.createDataFrame(
                 [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet the expectation1(ignore) & expectation2(drop)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row doesn't meet the expectation2(drop)
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all the expectations
-                ]
-            ),
-            [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "col1 > 1",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "col1 value must be greater than 1",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "10",
+                    }
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                # expected res
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a"},
+                        {"col1": 2, "col2": "b"},
+                        {"col1": 3, "col2": "c"},
+                    ]
+                ),
+                3,  # input count
+                1,  # error count
+                3,  # output count
+                None,  # source_agg_dq_res
+                None,  # final_agg_dq_res
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
                 {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "col1 > 1",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                    "description": "col1 value must be greater than 1",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "0",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "col3 > 5",
-                    "action_if_failed": "drop",
-                    "tag": "strict",
-                    "description": "col3 value must be greater than 5",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "10",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_mul_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(col3*col1) > 1",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                    "description": "col3_mul_col1 value must be equals to 1",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            True,  # write to table
-            True,  # write_to_temp_table
-            spark.createDataFrame(  # expected output
-                [
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),
-            3,  # input count
-            2,  # error count
-            1,  # output count
-            None,  # source_agg_result
-            None,  # final_agg_result
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 3, "num_row_dq_rules": 3},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
-                },
-            },  # dq_rules
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",  # status
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-        ),
-        (
-            # Test case 8
-            # In this test case, dq run set for source_agg_dq
-            # collect stats in the test_stats_table
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "agg_dq",
-                    "rule": "sum_col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "sum(col3) > 20",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                    "description": "sum col3 value must be greater than 20",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "10",
-                }
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),  # expected result
-            3,  # input count
-            0,  # error count
-            0,  # output count
-            [
-                {
-                    "description": "sum col3 value must be greater than 20",  # source_ag_result
-                    "rule": "sum_col3_threshold",
-                    "rule_type": "agg_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                }
-            ],
-            None,  # final_agg_result
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 1,
-                    "num_agg_dq_rules": 1,
-                    "num_final_agg_dq_rules": 1,
-                },
-            },  # dq_rules
-            {
-                "row_dq_status": "Skipped",
-                "source_agg_dq_status": "Passed",  # status
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-        ),
-        (
-            # Test case 9
-            # In this test case, dq run set for source_agg_dq with action_if_failed fail
-            # collect stats in the test_stats_table
-            spark.createDataFrame(
-                [
-                    # avg of col3 is not more than 25
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "agg_dq",
-                    "rule": "avg_col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "avg(col3) > 25",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                    "description": "avg col3 value must be greater than 25",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                }
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            SparkExpectationsMiscException,  # excepted result
-            3,  # input count
-            0,  # error count
-            0,  # output count
-            [
-                {
-                    "description": "avg col3 value must be greater than 25",  # source_agg_result
-                    "rule": "avg_col3_threshold",
-                    "rule_type": "agg_dq",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                }
-            ],
-            None,  # final_agg_result
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 1,
-                    "num_agg_dq_rules": 1,
-                    "num_final_agg_dq_rules": 1,
-                },
-            },  # dq_rules
-            {
-                "row_dq_status": "Skipped",
-                "source_agg_dq_status": "Failed",  # status
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Failed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-        ),
-        (
-            # Test case 10
-            # In this test case, dq run set for final_agg_dq with action_if_failed ignore
-            # collect stats in the test_stats_table
-            spark.createDataFrame(
-                [
-                    # minimum of col1 must be greater than 10
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "agg_dq",
-                    "rule": "min_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "min(col1) > 10",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                    "description": "min col1 value must be greater than 10",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col2_set",
-                    "column_name": "col2",
-                    "expectation": "col2 in  ('a', 'c')",
-                    "action_if_failed": "drop",
-                    "tag": "strict",
-                    "description": "col2 value must be in ('a', 'b')",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "0",
-                },
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),  # expected result but row_dq set to false
-            3,  # input count
-            1,  # error count
-            2,  # output count
-            None,  # source_agg-result
-            [
-                {
-                    "description": "min col1 value must be greater than 10",
-                    "rule": "min_col1_threshold",
-                    "rule_type": "agg_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                }
-            ],
-            # final_agg_result
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 1},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 1,
-                    "num_agg_dq_rules": 1,
-                    "num_final_agg_dq_rules": 1,
-                },
-            },  # dq_rules
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Passed",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-        ),
-        (
-            # Test case 11
-            # In this test case, dq run set for row_dq & final_agg_dq
-            # with action_if_failed drop(row), fail(agg)
-            # collect stats in the test_stats_table & error into error_table
-            spark.createDataFrame(
-                # standard deviation of col3 must be greater than 10
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row meet expectation
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row doesn't meet expectation
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets expectations
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "agg_dq",
-                    "rule": "std_col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "stddev(col3) > 10",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                    "description": "std col3 value must be greater than 10",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col2_set",
-                    "column_name": "col2",
-                    "expectation": "col2 in  ('a', 'c')",
-                    "action_if_failed": "drop",
-                    "tag": "strict",
-                    "description": "col2 value must be in ('a', 'b')",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "15",
-                },
-            ],
-            True,  # write to table
-            True,  # write temp table
-            SparkExpectationsMiscException,  # expected result
-            3,  # input count
-            1,  # error count
-            2,  # output count
-            None,  # source_agg_result
-            [
-                {
-                    "description": "std col3 value must be greater than 10",
-                    "rule": "std_col3_threshold",
-                    "rule_type": "agg_dq",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                }
-            ],
-            # final_agg_result
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 1},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 1,
-                    "num_agg_dq_rules": 1,
-                    "num_final_agg_dq_rules": 1,
-                },
-            },  # dq_rules
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Failed",
-                "run_status": "Failed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
-            # status
-        ),
-        (
-            # Test case 12
-            # In this test case, dq run set for row_dq
-            # with action_if_failed drop
-            # collect stats in the test_stats_table & error into error_table
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a"},
-                    # row doesn't meet the expectations
-                    {"col1": 2, "col2": "b"},
-                    # row meets the expectation
-                    {"col1": 3, "col2": "c"},
-                    # row meets the expectations
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "col1 > 1",
-                    "action_if_failed": "drop",
-                    "tag": "validity",
-                    "description": "col1 value must be greater than 1",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "0",
-                }
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            spark.createDataFrame(
-                [{"col1": 2, "col2": "b"}, {"col1": 3, "col2": "c"}]  # expected_output
-            ),  # expected result
-            3,  # input count
-            1,  # error count
-            2,  # output count
-            None,  # source_agg_result
-            None,  # final_agg_result
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
-                },
-            },  # dq_rules
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },  # status
-        ),
-        (
-            # Test case 13
-            # In this test case, dq run set for row_dq  & source_agg_dq
-            # with action_if_failed (ignore, drop) and ignore(agg_dq)
-            # collect stats in the test_stats_table & error into error_table
-            spark.createDataFrame(
-                [
-                    # count of distinct element in col2 must be greater than 2
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet expectation1(ignore)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets all row_dq expectations
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all row_dq expectations
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col1_threshold_1",
-                    "column_name": "col1",
-                    "expectation": "col1 > 1",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "col1 value must be greater than 1",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "10",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col2_set",
-                    "column_name": "col2",
-                    "expectation": "col2 in ('a', 'b', 'c')",
-                    "action_if_failed": "drop",
-                    "tag": "validity",
-                    "description": "col1 value must be greater than 2",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "10",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "agg_dq",
-                    "rule": "distinct_col2_threshold",
-                    "column_name": "col2",
-                    "expectation": "count(distinct col2) > 4",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "distinct of col2 value must be greater than 4",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            spark.createDataFrame(
-                [  # expected_output
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),
-            3,  # input count
-            1,  # error count
-            3,  # output count
-            [
-                {
-                    "description": "distinct of col2 value must be greater than 4",
-                    "rule": "distinct_col2_threshold",
-                    "rule_type": "agg_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                }
-            ],
-            # source_agg_result
-            None,  # final_agg_result
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 3, "num_row_dq_rules": 2},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 1,
-                    "num_agg_dq_rules": 1,
-                    "num_final_agg_dq_rules": 1,
-                },
-            },  # dq_rules
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Passed",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },  # status
-        ),
-        (
-            # Test case 14
-            # In this test case, dq run set for row_dq, source_agg_dq & final_agg_dq
-            # with action_if_failed r(ignore, drop) for row_dq  and (ignore) for agg_dq
-            # collect stats in the test_stats_table & error into error_table
-            spark.createDataFrame(
-                [
-                    # avg of col1 must be greater than 4(ignore) for agg_dq
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet row_dq expectation1(ignore)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row doesn't meet row_dq expectation2(drop)
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all row-dq expectations
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_threshold_4",
-                    "column_name": "col3",
-                    "expectation": "col3 > 4",
-                    "action_if_failed": "drop",
-                    "tag": "validity",
-                    "description": "col3 value must be greater than 4",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col2_set",
-                    "column_name": "col2",
-                    "expectation": "col2 in ('a', 'b')",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "col2 value must be in (a, b)",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "2",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "agg_dq",
-                    "rule": "avg_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "avg(col1) > 4",
-                    "action_if_failed": "ignore",
-                    "tag": "accuracy",
-                    "description": "avg of col1 value must be greater than 4",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            spark.createDataFrame(
-                [  # expected_output
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),  # expected result
-            3,  # input count
-            2,  # error count
-            2,  # output count
-            [
-                {
-                    "description": "avg of col1 value must be greater than 4",
-                    "rule": "avg_col1_threshold",
-                    "rule_type": "agg_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "accuracy",
-                }
-            ],
-            # source_agg_dq
-            [
-                {
-                    "description": "avg of col1 value must be greater than 4",
-                    "rule": "avg_col1_threshold",
-                    "rule_type": "agg_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "accuracy",
-                }
-            ],
-            # final_agg_dq
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 3, "num_row_dq_rules": 2},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
-                },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 1,
-                    "num_agg_dq_rules": 1,
-                    "num_final_agg_dq_rules": 1,
-                },
-            },  # dq_rules
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Passed",
-                "final_agg_dq_status": "Passed",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },  # status
-        ),
-        (
-            # Test case 15
-            # In this test case, dq run set for row_dq, source_agg_dq & final_agg_dq
-            # with action_if_failed (ignore, drop) for row_dq  and (ignore, fail) for agg_dq
-            # collect stats in the test_stats_table & error into error_table
-            spark.createDataFrame(
-                [
-                    # average of col1 must be greater than 4(ignore)
-                    # standard deviation of col1 must be greater than 0(fail)
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets all row_dq_expectations
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all row_dq_expectations
-                    {"col1": 2, "col2": "d", "col3": 7},
-                ]
-            ),
-            [
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_and_col1_threshold_4",
-                    "column_name": "col3, col1",
-                    "expectation": "((col3 * col1) - col3) > 5",
-                    "action_if_failed": "drop",
-                    "tag": "validity",
-                    "description": "col3 and col1 operation value must be greater than 3",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "25",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col2_set",
-                    "column_name": "col2",
-                    "expectation": "col2 in ('b', 'c')",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "col2 value must be in (b, c)",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "30",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "agg_dq",
-                    "rule": "avg_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "avg(col1) > 4",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "avg of col1 value must be greater than 4",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "agg_dq",
-                    "rule": "stddev_col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "stddev(col3) > 1",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "stddev of col3 value must be greater than one",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            spark.createDataFrame(
-                [  # expected_output
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    {"col1": 2, "col2": "d", "col3": 7},
-                ]
-            ),  # expected result
-            4,  # input count
-            3,  # error count
-            2,  # output count
-            [
-                {
-                    "description": "avg of col1 value must be greater than 4",
-                    "rule": "avg_col1_threshold",
-                    "rule_type": "agg_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                }
-            ],
-            # source_agg_result
-            [
-                {
-                    "action_if_failed": "ignore",
-                    "description": "avg of col1 value must be greater than 4",
-                    "rule": "avg_col1_threshold",
-                    "rule_type": "agg_dq",
-                    "tag": "validity",
-                },
-                {
-                    "action_if_failed": "ignore",
-                    "description": "stddev of col3 value must be greater than one",
-                    "rule": "stddev_col3_threshold",
-                    "rule_type": "agg_dq",
-                    "tag": "validity",
-                },
-            ],
-            # final_agg_result
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 5, "num_row_dq_rules": 2},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
+                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
                 },  # dq_rules
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 2,
-                    "num_agg_dq_rules": 3,
-                    "num_final_agg_dq_rules": 2,
+                # status at different stages for given input
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-            },
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Passed",
-                "final_agg_dq_status": "Passed",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },  # status
         ),
         (
-            # Test case 16
-            # In this test case, dq run set for query_dq source_query_dq
-            # with action_if_failed (ignore) for query_dq
-            # collect stats in the test_stats_table & error into error_table
-            spark.createDataFrame(
+                # test case 1
+                # In this test case, the action for failed rows is "drop",
+                # collect stats in the test_stats_table and
+                # log the error records into the error table.
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row  meets expectations(drop), log into err & fnl
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row doesn't meets expectations(drop), log into final table
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets expectations(drop), log into final table
+                    ]
+                ),
                 [
-                    # sum of col1 must be greater than 10(ignore)
-                    # standard deviation of col3 must be greater than 0(ignore)
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet row_dq expectation1(drop)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets all row_dq_expectations
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all row_dq_expectations
-                ]
-            ),
-            [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col2_set",
+                        "column_name": "col2",
+                        "expectation": "col2 in  ('a', 'c')",
+                        "action_if_failed": "drop",
+                        "tag": "strict",
+                        "description": "col2 value must be in ('a', 'b')",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "5",
+                    }
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                # expected res
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet expectations(ignore), log into err & fnl
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets expectations(ignore), log into final table
+                    ]
+                ),
+                3,  # input count
+                1,  # error count
+                2,  # output count
+                None,  # source_agg_dq_res
+                None,  # final_agg_dq_res
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
                 {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "sum_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(select sum(col1) from test_table) > 10",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "sum of col1 value must be greater than 10",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "stddev_col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "(select stddev(col3) from test_table) > 0",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "stddev of col3 value must be greater than 0",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            False,  # write to table
-            False,  # write to temp table
-            None,  # expected result
-            3,  # input count
-            0,  # error count
-            0,  # output count
-            None,  # source_agg_result
-            None,  # final_agg_result
-            # final_agg_result
-            [
-                {
-                    "description": "sum of col1 value must be greater than 10",
-                    "rule": "sum_col1_threshold",
-                    "rule_type": "query_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                }
-            ],
-            # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 2,
-                    "num_source_query_dq_rules": 2,
-                    "num_query_dq_rules": 2,
+                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
                 },  # dq_rules
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
+                # status at different stages for given input
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-            },
-            {
-                "row_dq_status": "Skipped",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Passed",
-                "final_query_dq_status": "Skipped",
-            },  # status
         ),
         (
-            # Test case 17
-            # In this test case, dq run set for query_dq final_query_dq
-            # with action_if_failed (ignore) for query_dq
-            # collect stats in the test_stats_table & error into error_table
-            spark.createDataFrame(
+                # test case 2
+                # In this test case, the action for failed rows is "fail",
+                # spark expectations expected to fail
+                # collect stats in the test_stats_table and
+                # log the error records into the error table.
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet expectations(fail), log into err & fnl
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets doesn't expectations(fail), log into final table
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets doesn't expectations(fail), log into final table
+                    ]
+                ),
                 [
-                    # max of col1 must be greater than 10(ignore)
-                    # min of col3 must be greater than 0(ignore)
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets all row_dq_expectations
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all row_dq_expectations
-                ]
-            ),
-            [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "col3 > 6",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                        "description": "col3 value must be greater than 6",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "15",
+                    }
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                SparkExpectationsMiscException,  # expected res
+                3,  # input count
+                3,  # error count
+                0,  # output count
+                None,  # source_agg_dq_res
+                None,  # final_agg_dq_res
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
                 {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_and_col1_threshold_4",
-                    "column_name": "col3, col1",
-                    "expectation": "((col3 * col1) - col3) > 5",
-                    "action_if_failed": "drop",
-                    "tag": "validity",
-                    "description": "col3 and col1 operation value must be greater than 3",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "max_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(select max(col1) from test_final_table_view) > 10",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                    "description": "max of col1 value must be greater than 10",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "min_col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "(select min(col3) from test_final_table_view) > 0",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "min of col3 value must be greater than 0",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            True,  # write to table
-            False,  # write to temp table
-            spark.createDataFrame(
-                [
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),  # expected result
-            3,  # input count
-            2,  # error count
-            1,  # output count
-            None,  # source_agg_result
-            None,  # final_agg_result
-            # final_agg_result
-            None,  # source_query_dq_res
-            [
-                {
-                    "description": "max of col1 value must be greater than 10",
-                    "rule": "max_col1_threshold",
-                    "rule_type": "query_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                }
-            ],
-            # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 3, "num_row_dq_rules": 1},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 2,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 2,
+                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
                 },  # dq_rules
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
+                # status at different stages for given input
+                {
+                    "row_dq_status": "Failed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Failed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-            },
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Passed",
-            },  # status
         ),
-        (
-            # Test case 18
-            # In this test case, dq run set for query_dq source_query_dq(ignore, fail)
-            # with action_if_failed (fail) for query_dq
-            # collect stats in the test_stats_table, error into error_table & raises the error
-            spark.createDataFrame(
+        (  # test case 3
+                # In this test case, the action for failed rows is "ignore" & "drop",
+                # collect stats in the test_stats_table and
+                # log the error records into the error table.
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet expectations1(ignore) 2(drop), log into err & fnl
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets expectations1(ignore), log into final table
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row doesnt'meets expectations1(ignore), log into final table
+                    ]
+                ),
                 [
-                    # min of col1 must be greater than 10(fail)
-                    # standard deviation of col3 must be greater than 0(ignore)
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet row_dq expectation1(drop)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets all row_dq_expectations
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all row_dq_expectations
-                ]
-            ),
-            [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "col3 > 6",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                        "description": "col3 value must be greater than 6",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "10",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col1_add_col3_threshold",
+                        "column_name": "col1",
+                        "expectation": "(col1+col3) > 6",
+                        "action_if_failed": "drop",
+                        "tag": "strict",
+                        "description": "col1_add_col3 value must be greater than 6",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "15",
+                    },
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                # expected res
+                spark.createDataFrame(
+                    [
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),
+                3,  # input count
+                3,  # error count
+                2,  # output count
+                None,  # source_agg_dq_res
+                None,  # final_agg_dq_res
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
                 {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "min_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(select min(col1) from test_final_table_view) > 10",
-                    "action_if_failed": "fail",
-                    "tag": "validity",
-                    "description": "min of col1 value must be greater than 10",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "stddev_col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "(select stddev(col3) from test_final_table_view) > 0",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "stddev of col3 value must be greater than 0",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            False,  # write to table
-            False,  # write to temp table
-            SparkExpectationsMiscException,  # expected result
-            3,  # input count
-            0,  # error count
-            0,  # output count
-            None,  # source_agg_result
-            None,  # final_agg_result
-            [
-                {
-                    "action_if_failed": "fail",
-                    "description": "min of col1 value must be greater than 10",
-                    "rule": "min_col1_threshold",
-                    "rule_type": "query_dq",
-                    "tag": "validity",
-                },
-                {
-                    "action_if_failed": "ignore",
-                    "description": "stddev of col3 value must be greater than 0",
-                    "rule": "stddev_col3_threshold",
-                    "rule_type": "query_dq",
-                    "tag": "validity",
-                },
-            ],  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 2,
-                    "num_source_query_dq_rules": 2,
-                    "num_query_dq_rules": 2,
+                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
                 },  # dq_rules
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
+                # status at different stages for given input
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-            },
-            {
-                "row_dq_status": "Skipped",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Failed",
-                "source_query_dq_status": "Failed",
-                "final_query_dq_status": "Skipped",
-            },  # status
         ),
         (
-            # Test case 19
-            # In this test case, dq run set for query_dq final_query_dq(ignore, fail)
-            # with action_if_failed (ignore, fail) for query_dq
-            # collect stats in the test_stats_table, error into error_table & raises error
-            spark.createDataFrame(
+                # test case 4
+                # In this test case, the action for failed rows is "ignore" & "fail",
+                # collect stats in the test_stats_table and
+                # log the error records into the error table.
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet expectations1(ignore), log into err & fnl
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets expectations1(ignore), log into final table
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets expectations1(ignore), log into final table
+                    ]
+                ),
                 [
-                    # max of col1 must be greater than 10(ignore)
-                    # min of col3 must be greater than 0(ignore)
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets all row_dq_expectations
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all row_dq_expectations
-                ]
-            ),
-            [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "col3 > 6",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                        "description": "col3 value must be greater than 6",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_minus_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(col3-col1) > 1",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                        "description": "col3_minus_col1 value must be greater than 1",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "5",
+                    },
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                # expected res
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),
+                3,  # input count
+                3,  # error count
+                3,  # output count
+                None,  # source_agg_dq_res
+                None,  # final_agg_dq_res
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
                 {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_and_col1_threshold_4",
-                    "column_name": "col3, col1",
-                    "expectation": "((col3 * col1) - col3) > 5",
-                    "action_if_failed": "drop",
-                    "tag": "validity",
-                    "description": "col3 and col1 operation value must be greater than 3",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "25",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "max_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(select max(col1) from test_final_table_view) > 10",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                    "description": "max of col1 value must be greater than 10",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "min_col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "(select min(col3) from test_final_table_view) > 0",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "min of col3 value must be greater than 0",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            True,  # write to table
-            False,  # write to temp table
-            SparkExpectationsMiscException,  # expected result
-            3,  # input count
-            2,  # error count
-            1,  # output count
-            None,  # source_agg_result
-            None,  # final_agg_result
-            # final_agg_result
-            None,  # source_query_dq_res
-            [
-                {
-                    "description": "max of col1 value must be greater than 10",
-                    "rule": "max_col1_threshold",
-                    "rule_type": "query_dq",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                }
-            ],
-            # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 3, "num_row_dq_rules": 1},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 2,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 2,
+                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
                 },  # dq_rules
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
+                # status at different stages for given input
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-            },
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Failed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Failed",
-            },  # status
         ),
         (
-            # Test case 20
-            # In this test case, dq run set for query_dq source_query_dq &
-            # final_query_dq(ignore, fail)
-            # with action_if_failed (ignore, fail) for query_dq
-            # collect stats in the test_stats_table, error into error_table
-            spark.createDataFrame(
+                # Test case 5
+                # In this test case, the action for failed rows is "drop" & "fail",
+                # collect stats in the test_stats_table and
+                # log the error records into the error table.
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet expectations1(drop) & 2(drop), log into err & fnl
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets expectations1(drop) & 2(fail), log into final table
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets expectations1(drop), & 2(fail) log into final table
+                    ]
+                ),
                 [
-                    # min of col1 must be greater than 10(ignore) - source_query_dq
-                    # max of col1 must be greater than 100(ignore) - final_query_dq
-                    # min of col3 must be greater than 0(fail) - final_query_dq
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row meets all row_dq_expectations(drop)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # ow doesn't meet row_dq expectation1(drop)
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all row_dq_expectations
-                ]
-            ),
-            [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "col3 > 6",
+                        "action_if_failed": "drop",
+                        "tag": "strict",
+                        "description": "col3 value must be greater than 6",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "25",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_minus_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(col3-col1) = 1",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                        "description": "col3_minus_col1 value must be equals to 1",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "25",
+                    },
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                SparkExpectationsMiscException,  # expected res
+                3,  # input count
+                3,  # error count
+                0,  # output count
+                None,  # source_agg_dq_res
+                None,  # final_agg_dq_res
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
                 {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_mod_2",
-                    "column_name": "col3",
-                    "expectation": "(col3 % 2) = 0",
-                    "action_if_failed": "drop",
-                    "tag": "validity",
-                    "description": "col3 mod must equals to 0",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": True,
-                    "error_drop_threshold": "40",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "min_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(select min(col1) from test_final_table_view) > 10",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                    "description": "min of col1 value must be greater than 10",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "max_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(select max(col1) from test_final_table_view) > 100",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                    "description": "max of col1 value must be greater than 100",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "min_col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "(select min(col3) from test_final_table_view) > 0",
-                    "action_if_failed": "fail",
-                    "tag": "validity",
-                    "description": "min of col3 value must be greater than 0",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            True,  # write to table
-            False,  # write to temp table
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),  # expected result
-            3,  # input count
-            1,  # error count
-            2,  # output count
-            None,  # source_agg_result
-            None,  # final_agg_result
-            # final_agg_result
-            [
-                {
-                    "description": "min of col1 value must be greater than 10",
-                    "rule": "min_col1_threshold",
-                    "rule_type": "query_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                }
-            ],
-            # source_query_dq_res
-            [
-                {
-                    "description": "max of col1 value must be greater than 100",
-                    "rule": "max_col1_threshold",
-                    "rule_type": "query_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                }
-            ],
-            # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 2,
-                    "num_source_query_dq_rules": 1,
-                    "num_query_dq_rules": 3,
+                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
                 },  # dq_rules
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
+                # status at different stages for given input
+                {
+                    "row_dq_status": "Failed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Failed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-            },
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Passed",
-                "final_query_dq_status": "Passed",
-            },  # status
         ),
-        (
-            # Test case 21
-            # In this test case, dq run set for query_dq source_query_dq &
-            # final_query_dq(ignore, fail)
-            # with action_if_failed (ignore, fail) for query_dq
-            # collect stats in the test_stats_table, error into error_table & raise the error
-            spark.createDataFrame(
+        (  # Test case 6
+                # In this test case, the action for failed rows is "drop" & "fail",
+                # collect stats in the test_stats_table and
+                # log the error records into the error table
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet expectations1(drop) & meets 2(fail), log into err & fnl
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets expectations1(drop) & meets 2(fail), log into final table
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets expectations1(drop) & meets 2(fail), log into final table
+                    ]
+                ),
                 [
-                    # min of col1 must be greater than 10(ignore) - source_query_dq
-                    # max of col1 must be greater than 100(fail) - final_query_dq
-                    # min of col3 must be greater than 0(fail) - final_query_dq
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row meets all row_dq_expectations(drop)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # ow doesn't meet row_dq expectation1(drop)
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all row_dq_expectations
-                ]
-            ),
-            [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "col3 > 6",
+                        "action_if_failed": "drop",
+                        "tag": "strict",
+                        "description": "col3 value must be greater than 6",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "10",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_mul_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(col3*col1) > 1",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                        "description": "col3_mul_col1 value must be equals to 1",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "10",
+                    },
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                # expected res
+                spark.createDataFrame(
+                    [],
+                    schema=StructType(
+                        [
+                            StructField("col1", IntegerType()),
+                            StructField("col2", StringType()),
+                            StructField("col3", IntegerType()),
+                        ]
+                    ),
+                ),
+                3,  # input count
+                3,  # error count
+                0,  # output count
+                None,  # source_agg_dq_res
+                None,  # final_agg_dq_res
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
                 {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_mod_2",
-                    "column_name": "col3",
-                    "expectation": "(col3 % 2) = 0",
-                    "action_if_failed": "drop",
-                    "tag": "validity",
-                    "description": "col3 mod must equals to 0",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "10",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "min_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(select min(col1) from test_final_table_view) > 10",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                    "description": "min of col1 value must be greater than 10",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "max_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(select max(col1) from test_final_table_view) > 100",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                    "description": "max of col1 value must be greater than 100",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "min_col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "(select min(col3) from test_final_table_view) > 0",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "min of col3 value must be greater than 0",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            True,  # write to table
-            False,  # write to temp table
-            SparkExpectationsMiscException,  # expected result
-            3,  # input count
-            1,  # error count
-            2,  # output count
-            None,  # source_agg_result
-            None,  # final_agg_result
-            # final_agg_result
-            [
-                {
-                    "description": "min of col1 value must be greater than 10",
-                    "rule": "min_col1_threshold",
-                    "rule_type": "query_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                }
-            ],
-            # source_query_dq_res
-            [
-                {
-                    "description": "max of col1 value must be greater than 100",
-                    "rule": "max_col1_threshold",
-                    "rule_type": "query_dq",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                }
-            ],
-            # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 2,
-                    "num_source_query_dq_rules": 1,
-                    "num_query_dq_rules": 3,
+                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 2},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
                 },  # dq_rules
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
+                # status at different stages for given input
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-            },
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Failed",
-                "source_query_dq_status": "Passed",
-                "final_query_dq_status": "Failed",
-            },  # status
         ),
         (
-            # Test case 22
-            # In this test case, dq run set for query_dq source_query_dq &
-            # final_query_dq(ignore, fail)
-            # with action_if_failed (ignore, fail) for query_dq
-            # collect stats in the test_stats_table, error into error_table & raise the error
-            spark.createDataFrame(
+                # Test case 7
+                # In this test case, the action for failed rows is "ignore", "drop" & "fail",
+                # collect stats in the test_stats_table and
+                # log the error records into the error table
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet the expectation1(ignore) & expectation2(drop)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row doesn't meet the expectation2(drop)
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all the expectations
+                    ]
+                ),
                 [
-                    # min of col1 must be greater than 10(ignore) - source_query_dq
-                    # max of col1 must be greater than 100(fail) - final_query_dq
-                    # min of col3 must be greater than 0(fail) - final_query_dq
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row meets all row_dq_expectations(drop)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # ow doesn't meet row_dq expectation1(drop)
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all row_dq_expectations
-                ]
-            ),
-            [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "col1 > 1",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                        "description": "col1 value must be greater than 1",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "0",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "col3 > 5",
+                        "action_if_failed": "drop",
+                        "tag": "strict",
+                        "description": "col3 value must be greater than 5",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "10",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_mul_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(col3*col1) > 1",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                        "description": "col3_mul_col1 value must be equals to 1",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                True,  # write to table
+                True,  # write_to_temp_table
+                spark.createDataFrame(  # expected output
+                    [
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),
+                3,  # input count
+                2,  # error count
+                1,  # output count
+                None,  # source_agg_result
+                None,  # final_agg_result
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
                 {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "agg_dq",
-                    "rule": "col3_max_value",
-                    "column_name": "col3",
-                    "expectation": "max(col3) > 1",
-                    "action_if_failed": "fail",
-                    "tag": "validity",
-                    "description": "col3 mod must equals to 0",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "row_dq",
-                    "rule": "col3_mod_2",
-                    "column_name": "col3",
-                    "expectation": "(col3 % 2) = 0",
-                    "action_if_failed": "drop",
-                    "tag": "validity",
-                    "description": "col3 mod must equals to 0",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "100",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "count_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(select count(col1) from test_final_table_view) > 3",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                    "description": "count of col1 value must be greater than 3",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "col3_positive_threshold",
-                    "column_name": "col1",
-                    "expectation": "(select count(case when col3>0 then 1 else 0 end) from "
-                    "test_final_table_view) > 10",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                    "description": "count of col3 positive value must be greater than 10",
-                    "enable_for_source_dq_validation": False,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            True,  # write to table
-            False,  # write to temp table
-            spark.createDataFrame(
-                [
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),  # expected result
-            3,  # input count
-            1,  # error count
-            2,  # output count
-            None,  # source_agg_result
-            None,  # final_agg_result
-            # final_agg_result
-            [
-                {
-                    "description": "count of col1 value must be greater than 3",
-                    "rule": "count_col1_threshold",
-                    "rule_type": "query_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                }
-            ],
-            # source_query_dq_res
-            [
-                {
-                    "description": "count of col3 positive value must be greater than 10",
-                    "rule": "col3_positive_threshold",
-                    "rule_type": "query_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "strict",
-                }
-            ],
-            # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 1,
-                    "num_source_query_dq_rules": 1,
-                    "num_query_dq_rules": 2,
+                    "rules": {"num_dq_rules": 3, "num_row_dq_rules": 3},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
                 },  # dq_rules
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 1,
-                    "num_agg_dq_rules": 1,
-                    "num_final_agg_dq_rules": 1,
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",  # status
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-            },
-            {
-                "row_dq_status": "Passed",
-                "source_agg_dq_status": "Passed",
-                "final_agg_dq_status": "Passed",
-                "run_status": "Passed",
-                "source_query_dq_status": "Passed",
-                "final_query_dq_status": "Passed",
-            },  # status
         ),
         (
-            # Test case 23
-            # In this test case, dq run set for query_dq source_query_dq and one of the rule is parameterized
-            # with action_if_failed (ignore) for query_dq
-            # collect stats in the test_stats_table & error into error_table
-            spark.createDataFrame(
+                # Test case 8
+                # In this test case, dq run set for source_agg_dq
+                # collect stats in the test_stats_table
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),
                 [
-                    # sum of col1 must be greater than 10(ignore)
-                    # standard deviation of col3 must be greater than 0(ignore)
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    # row doesn't meet row_dq expectation1(drop)
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    # row meets all row_dq_expectations
-                    {"col1": 3, "col2": "c", "col3": 6},
-                    # row meets all row_dq_expectations
-                ]
-            ),
-            [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "agg_dq",
+                        "rule": "sum_col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "sum(col3) > 20",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                        "description": "sum col3 value must be greater than 20",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "10",
+                    }
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),  # expected result
+                3,  # input count
+                0,  # error count
+                0,  # output count
+                [
+                    {
+                        "description": "sum col3 value must be greater than 20",  # source_ag_result
+                        "rule": "sum_col3_threshold",
+                        "rule_type": "agg_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                    }
+                ],
+                None,  # final_agg_result
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
                 {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "sum_col1_threshold",
-                    "column_name": "col1",
-                    "expectation": "(select sum(col1) from {table}) > 10",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "sum of col1 value must be greater than 10",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-                {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "query_dq",
-                    "rule": "stddev_col3_threshold",
-                    "column_name": "col3",
-                    "expectation": "(select stddev(col3) from test_table) > 0",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                    "description": "stddev of col3 value must be greater than 0",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": True,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                },
-            ],
-            False,  # write to table
-            False,  # write to temp table
-            None,  # expected result
-            3,  # input count
-            0,  # error count
-            0,  # output count
-            None,  # source_agg_result
-            None,  # final_agg_result
-            # final_agg_result
-            [
-                {
-                    "description": "sum of col1 value must be greater than 10",
-                    "rule": "sum_col1_threshold",
-                    "rule_type": "query_dq",
-                    "action_if_failed": "ignore",
-                    "tag": "validity",
-                }
-            ],
-            # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 2,
-                    "num_source_query_dq_rules": 2,
-                    "num_query_dq_rules": 2,
+                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 1,
+                        "num_agg_dq_rules": 1,
+                        "num_final_agg_dq_rules": 1,
+                    },
                 },  # dq_rules
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 0,
-                    "num_agg_dq_rules": 0,
-                    "num_final_agg_dq_rules": 0,
+                {
+                    "row_dq_status": "Skipped",
+                    "source_agg_dq_status": "Passed",  # status
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-            },
-            {
-                "row_dq_status": "Skipped",
-                "source_agg_dq_status": "Skipped",
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Passed",
-                "source_query_dq_status": "Passed",
-                "final_query_dq_status": "Skipped",
-            },  # status
         ),
         (
-            # Test case 24
-            # In this test case, dq run set for source_agg_dq with action_if_failed fail
-            # with the sql syntax > lower_bound and < upper_bound
-            # collect stats in the test_stats_table
-            spark.createDataFrame(
+                # Test case 9
+                # In this test case, dq run set for source_agg_dq with action_if_failed fail
+                # collect stats in the test_stats_table
+                spark.createDataFrame(
+                    [
+                        # avg of col3 is not more than 25
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),
                 [
-                    # avg of col3 is greater than 18 and not more than 25
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),
-            [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "agg_dq",
+                        "rule": "avg_col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "avg(col3) > 25",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                        "description": "avg col3 value must be greater than 25",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    }
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                SparkExpectationsMiscException,  # excepted result
+                3,  # input count
+                0,  # error count
+                0,  # output count
+                [
+                    {
+                        "description": "avg col3 value must be greater than 25",  # source_agg_result
+                        "rule": "avg_col3_threshold",
+                        "rule_type": "agg_dq",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                    }
+                ],
+                None,  # final_agg_result
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
                 {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "agg_dq",
-                    "rule": "avg_col3_range",
-                    "column_name": "col3",
-                    "expectation": "avg(col3) > 18 and avg(col3) < 25",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                    "description": "avg col3 value must be greater than 18 and less than 25",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                }
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            SparkExpectationsMiscException,  # excepted result
-            3,  # input count
-            0,  # error count
-            0,  # output count
-            [
+                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 1,
+                        "num_agg_dq_rules": 1,
+                        "num_final_agg_dq_rules": 1,
+                    },
+                },  # dq_rules
                 {
-                    "description": "avg col3 value must be greater than 18 and less than 25",  # source_agg_result
-                    "rule": "avg_col3_range",
-                    "rule_type": "agg_dq",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                }
-            ],
-            None,  # final_agg_result
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
+                    "row_dq_status": "Skipped",
+                    "source_agg_dq_status": "Failed",  # status
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Failed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 1,
-                    "num_agg_dq_rules": 1,
-                    "num_final_agg_dq_rules": 1,
-                },
-            },  # dq_rules
-            {
-                "row_dq_status": "Skipped",
-                "source_agg_dq_status": "Failed",  # status
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Failed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
         ),
         (
-            # Test case 25
-            # In this test case, dq run set for source_agg_dq with action_if_failed fail
-            # with the sql syntax between lower_bound and upper_bound
-            # collect stats in the test_stats_table
-            spark.createDataFrame(
+                # Test case 10
+                # In this test case, dq run set for final_agg_dq with action_if_failed ignore
+                # collect stats in the test_stats_table
+                spark.createDataFrame(
+                    [
+                        # minimum of col1 must be greater than 10
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),
                 [
-                    # avg of col3 is greater than 18 and not more than 25
-                    {"col1": 1, "col2": "a", "col3": 4},
-                    {"col1": 2, "col2": "b", "col3": 5},
-                    {"col1": 3, "col2": "c", "col3": 6},
-                ]
-            ),
-            [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "agg_dq",
+                        "rule": "min_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "min(col1) > 10",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                        "description": "min col1 value must be greater than 10",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col2_set",
+                        "column_name": "col2",
+                        "expectation": "col2 in  ('a', 'c')",
+                        "action_if_failed": "drop",
+                        "tag": "strict",
+                        "description": "col2 value must be in ('a', 'b')",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "0",
+                    },
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),  # expected result but row_dq set to false
+                3,  # input count
+                1,  # error count
+                2,  # output count
+                None,  # source_agg-result
+                [
+                    {
+                        "description": "min col1 value must be greater than 10",
+                        "rule": "min_col1_threshold",
+                        "rule_type": "agg_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                    }
+                ],
+                # final_agg_result
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
                 {
-                    "product_id": "product1",
-                    "table_name": "dq_spark.test_final_table",
-                    "rule_type": "agg_dq",
-                    "rule": "avg_col3_range",
-                    "column_name": "col3",
-                    "expectation": "avg(col3) between 18 and 25",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                    "description": "avg col3 value must be greater than 18 and less than 25",
-                    "enable_for_source_dq_validation": True,
-                    "enable_for_target_dq_validation": False,
-                    "is_active": True,
-                    "enable_error_drop_alert": False,
-                    "error_drop_threshold": "20",
-                }
-            ],
-            True,  # write to table
-            True,  # write to temp table
-            SparkExpectationsMiscException,  # excepted result
-            3,  # input count
-            0,  # error count
-            0,  # output count
-            [
+                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 1},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 1,
+                        "num_agg_dq_rules": 1,
+                        "num_final_agg_dq_rules": 1,
+                    },
+                },  # dq_rules
                 {
-                    "description": "avg col3 value must be greater than 18 and less than 25",  # source_agg_result
-                    "rule": "avg_col3_range",
-                    "rule_type": "agg_dq",
-                    "action_if_failed": "fail",
-                    "tag": "strict",
-                }
-            ],
-            None,  # final_agg_result
-            None,  # source_query_dq_res
-            None,  # final_query_dq_res
-            {
-                "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
-                "query_dq_rules": {
-                    "num_final_query_dq_rules": 0,
-                    "num_source_query_dq_rules": 0,
-                    "num_query_dq_rules": 0,
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Passed",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-                "agg_dq_rules": {
-                    "num_source_agg_dq_rules": 1,
-                    "num_agg_dq_rules": 1,
-                    "num_final_agg_dq_rules": 1,
+        ),
+        (
+                # Test case 11
+                # In this test case, dq run set for row_dq & final_agg_dq
+                # with action_if_failed drop(row), fail(agg)
+                # collect stats in the test_stats_table & error into error_table
+                spark.createDataFrame(
+                    # standard deviation of col3 must be greater than 10
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row meet expectation
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row doesn't meet expectation
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "agg_dq",
+                        "rule": "std_col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "stddev(col3) > 10",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                        "description": "std col3 value must be greater than 10",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col2_set",
+                        "column_name": "col2",
+                        "expectation": "col2 in  ('a', 'c')",
+                        "action_if_failed": "drop",
+                        "tag": "strict",
+                        "description": "col2 value must be in ('a', 'b')",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "15",
+                    },
+                ],
+                True,  # write to table
+                True,  # write temp table
+                SparkExpectationsMiscException,  # expected result
+                3,  # input count
+                1,  # error count
+                2,  # output count
+                None,  # source_agg_result
+                [
+                    {
+                        "description": "std col3 value must be greater than 10",
+                        "rule": "std_col3_threshold",
+                        "rule_type": "agg_dq",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                    }
+                ],
+                # final_agg_result
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 1},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 1,
+                        "num_agg_dq_rules": 1,
+                        "num_final_agg_dq_rules": 1,
+                    },
+                },  # dq_rules
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Failed",
+                    "run_status": "Failed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
                 },
-            },  # dq_rules
-            {
-                "row_dq_status": "Skipped",
-                "source_agg_dq_status": "Failed",  # status
-                "final_agg_dq_status": "Skipped",
-                "run_status": "Failed",
-                "source_query_dq_status": "Skipped",
-                "final_query_dq_status": "Skipped",
-            },
+                # status
+        ),
+        (
+                # Test case 12
+                # In this test case, dq run set for row_dq
+                # with action_if_failed drop
+                # collect stats in the test_stats_table & error into error_table
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a"},
+                        # row doesn't meet the expectations
+                        {"col1": 2, "col2": "b"},
+                        # row meets the expectation
+                        {"col1": 3, "col2": "c"},
+                        # row meets the expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "col1 > 1",
+                        "action_if_failed": "drop",
+                        "tag": "validity",
+                        "description": "col1 value must be greater than 1",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "0",
+                    }
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                spark.createDataFrame(
+                    [{"col1": 2, "col2": "b"}, {"col1": 3, "col2": "c"}]  # expected_output
+                ),  # expected result
+                3,  # input count
+                1,  # error count
+                2,  # output count
+                None,  # source_agg_result
+                None,  # final_agg_result
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 1},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
+                },  # dq_rules
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
+                },  # status
+        ),
+        (
+                # Test case 13
+                # In this test case, dq run set for row_dq  & source_agg_dq
+                # with action_if_failed (ignore, drop) and ignore(agg_dq)
+                # collect stats in the test_stats_table & error into error_table
+                spark.createDataFrame(
+                    [
+                        # count of distinct element in col2 must be greater than 2
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet expectation1(ignore)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets all row_dq expectations
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all row_dq expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col1_threshold_1",
+                        "column_name": "col1",
+                        "expectation": "col1 > 1",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "col1 value must be greater than 1",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "10",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col2_set",
+                        "column_name": "col2",
+                        "expectation": "col2 in ('a', 'b', 'c')",
+                        "action_if_failed": "drop",
+                        "tag": "validity",
+                        "description": "col1 value must be greater than 2",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "10",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "agg_dq",
+                        "rule": "distinct_col2_threshold",
+                        "column_name": "col2",
+                        "expectation": "count(distinct col2) > 4",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "distinct of col2 value must be greater than 4",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                spark.createDataFrame(
+                    [  # expected_output
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),
+                3,  # input count
+                1,  # error count
+                3,  # output count
+                [
+                    {
+                        "description": "distinct of col2 value must be greater than 4",
+                        "rule": "distinct_col2_threshold",
+                        "rule_type": "agg_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                    }
+                ],
+                # source_agg_result
+                None,  # final_agg_result
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 3, "num_row_dq_rules": 2},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 1,
+                        "num_agg_dq_rules": 1,
+                        "num_final_agg_dq_rules": 1,
+                    },
+                },  # dq_rules
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Passed",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
+                },  # status
+        ),
+        (
+                # Test case 14
+                # In this test case, dq run set for row_dq, source_agg_dq & final_agg_dq
+                # with action_if_failed r(ignore, drop) for row_dq  and (ignore) for agg_dq
+                # collect stats in the test_stats_table & error into error_table
+                spark.createDataFrame(
+                    [
+                        # avg of col1 must be greater than 4(ignore) for agg_dq
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet row_dq expectation1(ignore)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row doesn't meet row_dq expectation2(drop)
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all row-dq expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_threshold_4",
+                        "column_name": "col3",
+                        "expectation": "col3 > 4",
+                        "action_if_failed": "drop",
+                        "tag": "validity",
+                        "description": "col3 value must be greater than 4",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col2_set",
+                        "column_name": "col2",
+                        "expectation": "col2 in ('a', 'b')",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "col2 value must be in (a, b)",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "2",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "agg_dq",
+                        "rule": "avg_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "avg(col1) > 4",
+                        "action_if_failed": "ignore",
+                        "tag": "accuracy",
+                        "description": "avg of col1 value must be greater than 4",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                spark.createDataFrame(
+                    [  # expected_output
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),  # expected result
+                3,  # input count
+                2,  # error count
+                2,  # output count
+                [
+                    {
+                        "description": "avg of col1 value must be greater than 4",
+                        "rule": "avg_col1_threshold",
+                        "rule_type": "agg_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "accuracy",
+                    }
+                ],
+                # source_agg_dq
+                [
+                    {
+                        "description": "avg of col1 value must be greater than 4",
+                        "rule": "avg_col1_threshold",
+                        "rule_type": "agg_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "accuracy",
+                    }
+                ],
+                # final_agg_dq
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 3, "num_row_dq_rules": 2},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 1,
+                        "num_agg_dq_rules": 1,
+                        "num_final_agg_dq_rules": 1,
+                    },
+                },  # dq_rules
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Passed",
+                    "final_agg_dq_status": "Passed",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
+                },  # status
+        ),
+        (
+                # Test case 15
+                # In this test case, dq run set for row_dq, source_agg_dq & final_agg_dq
+                # with action_if_failed (ignore, drop) for row_dq  and (ignore, fail) for agg_dq
+                # collect stats in the test_stats_table & error into error_table
+                spark.createDataFrame(
+                    [
+                        # average of col1 must be greater than 4(ignore)
+                        # standard deviation of col1 must be greater than 0(fail)
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets all row_dq_expectations
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all row_dq_expectations
+                        {"col1": 2, "col2": "d", "col3": 7},
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_and_col1_threshold_4",
+                        "column_name": "col3, col1",
+                        "expectation": "((col3 * col1) - col3) > 5",
+                        "action_if_failed": "drop",
+                        "tag": "validity",
+                        "description": "col3 and col1 operation value must be greater than 3",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "25",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col2_set",
+                        "column_name": "col2",
+                        "expectation": "col2 in ('b', 'c')",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "col2 value must be in (b, c)",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "30",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "agg_dq",
+                        "rule": "avg_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "avg(col1) > 4",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "avg of col1 value must be greater than 4",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "agg_dq",
+                        "rule": "stddev_col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "stddev(col3) > 1",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "stddev of col3 value must be greater than one",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                spark.createDataFrame(
+                    [  # expected_output
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        {"col1": 2, "col2": "d", "col3": 7},
+                    ]
+                ),  # expected result
+                4,  # input count
+                3,  # error count
+                2,  # output count
+                [
+                    {
+                        "description": "avg of col1 value must be greater than 4",
+                        "rule": "avg_col1_threshold",
+                        "rule_type": "agg_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                    }
+                ],
+                # source_agg_result
+                [
+                    {
+                        "action_if_failed": "ignore",
+                        "description": "avg of col1 value must be greater than 4",
+                        "rule": "avg_col1_threshold",
+                        "rule_type": "agg_dq",
+                        "tag": "validity",
+                    },
+                    {
+                        "action_if_failed": "ignore",
+                        "description": "stddev of col3 value must be greater than one",
+                        "rule": "stddev_col3_threshold",
+                        "rule_type": "agg_dq",
+                        "tag": "validity",
+                    },
+                ],
+                # final_agg_result
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 5, "num_row_dq_rules": 2},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },  # dq_rules
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 2,
+                        "num_agg_dq_rules": 3,
+                        "num_final_agg_dq_rules": 2,
+                    },
+                },
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Passed",
+                    "final_agg_dq_status": "Passed",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
+                },  # status
+        ),
+        (
+                # Test case 16
+                # In this test case, dq run set for query_dq source_query_dq
+                # with action_if_failed (ignore) for query_dq
+                # collect stats in the test_stats_table & error into error_table
+                spark.createDataFrame(
+                    [
+                        # sum of col1 must be greater than 10(ignore)
+                        # standard deviation of col3 must be greater than 0(ignore)
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet row_dq expectation1(drop)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets all row_dq_expectations
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all row_dq_expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "sum_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(select sum(col1) from test_table) > 10",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "sum of col1 value must be greater than 10",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "stddev_col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "(select stddev(col3) from test_table) > 0",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "stddev of col3 value must be greater than 0",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                False,  # write to table
+                False,  # write to temp table
+                None,  # expected result
+                3,  # input count
+                0,  # error count
+                0,  # output count
+                None,  # source_agg_result
+                None,  # final_agg_result
+                # final_agg_result
+                [
+                    {
+                        "description": "sum of col1 value must be greater than 10",
+                        "rule": "sum_col1_threshold",
+                        "rule_type": "query_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                    }
+                ],
+                # source_query_dq_res
+                None,  # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 2,
+                        "num_source_query_dq_rules": 2,
+                        "num_query_dq_rules": 2,
+                    },  # dq_rules
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
+                },
+                {
+                    "row_dq_status": "Skipped",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Passed",
+                    "final_query_dq_status": "Skipped",
+                },  # status
+        ),
+        (
+                # Test case 17
+                # In this test case, dq run set for query_dq final_query_dq
+                # with action_if_failed (ignore) for query_dq
+                # collect stats in the test_stats_table & error into error_table
+                spark.createDataFrame(
+                    [
+                        # max of col1 must be greater than 10(ignore)
+                        # min of col3 must be greater than 0(ignore)
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets all row_dq_expectations
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all row_dq_expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_and_col1_threshold_4",
+                        "column_name": "col3, col1",
+                        "expectation": "((col3 * col1) - col3) > 5",
+                        "action_if_failed": "drop",
+                        "tag": "validity",
+                        "description": "col3 and col1 operation value must be greater than 3",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "max_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(select max(col1) from test_final_table_view) > 10",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                        "description": "max of col1 value must be greater than 10",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "min_col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "(select min(col3) from test_final_table_view) > 0",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "min of col3 value must be greater than 0",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                True,  # write to table
+                False,  # write to temp table
+                spark.createDataFrame(
+                    [
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),  # expected result
+                3,  # input count
+                2,  # error count
+                1,  # output count
+                None,  # source_agg_result
+                None,  # final_agg_result
+                # final_agg_result
+                None,  # source_query_dq_res
+                [
+                    {
+                        "description": "max of col1 value must be greater than 10",
+                        "rule": "max_col1_threshold",
+                        "rule_type": "query_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                    }
+                ],
+                # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 3, "num_row_dq_rules": 1},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 2,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 2,
+                    },  # dq_rules
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
+                },
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Passed",
+                },  # status
+        ),
+        (
+                # Test case 18
+                # In this test case, dq run set for query_dq source_query_dq(ignore, fail)
+                # with action_if_failed (fail) for query_dq
+                # collect stats in the test_stats_table, error into error_table & raises the error
+                spark.createDataFrame(
+                    [
+                        # min of col1 must be greater than 10(fail)
+                        # standard deviation of col3 must be greater than 0(ignore)
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet row_dq expectation1(drop)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets all row_dq_expectations
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all row_dq_expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "min_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(select min(col1) from test_final_table_view) > 10",
+                        "action_if_failed": "fail",
+                        "tag": "validity",
+                        "description": "min of col1 value must be greater than 10",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "stddev_col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "(select stddev(col3) from test_final_table_view) > 0",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "stddev of col3 value must be greater than 0",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                False,  # write to table
+                False,  # write to temp table
+                SparkExpectationsMiscException,  # expected result
+                3,  # input count
+                0,  # error count
+                0,  # output count
+                None,  # source_agg_result
+                None,  # final_agg_result
+                [
+                    {
+                        "action_if_failed": "fail",
+                        "description": "min of col1 value must be greater than 10",
+                        "rule": "min_col1_threshold",
+                        "rule_type": "query_dq",
+                        "tag": "validity",
+                    },
+                    {
+                        "action_if_failed": "ignore",
+                        "description": "stddev of col3 value must be greater than 0",
+                        "rule": "stddev_col3_threshold",
+                        "rule_type": "query_dq",
+                        "tag": "validity",
+                    },
+                ],  # source_query_dq_res
+                None,  # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 2,
+                        "num_source_query_dq_rules": 2,
+                        "num_query_dq_rules": 2,
+                    },  # dq_rules
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
+                },
+                {
+                    "row_dq_status": "Skipped",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Failed",
+                    "source_query_dq_status": "Failed",
+                    "final_query_dq_status": "Skipped",
+                },  # status
+        ),
+        (
+                # Test case 19
+                # In this test case, dq run set for query_dq final_query_dq(ignore, fail)
+                # with action_if_failed (ignore, fail) for query_dq
+                # collect stats in the test_stats_table, error into error_table & raises error
+                spark.createDataFrame(
+                    [
+                        # max of col1 must be greater than 10(ignore)
+                        # min of col3 must be greater than 0(ignore)
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet row_dq expectation1(drop) and expectation2(ignore)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets all row_dq_expectations
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all row_dq_expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_and_col1_threshold_4",
+                        "column_name": "col3, col1",
+                        "expectation": "((col3 * col1) - col3) > 5",
+                        "action_if_failed": "drop",
+                        "tag": "validity",
+                        "description": "col3 and col1 operation value must be greater than 3",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "25",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "max_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(select max(col1) from test_final_table_view) > 10",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                        "description": "max of col1 value must be greater than 10",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "min_col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "(select min(col3) from test_final_table_view) > 0",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "min of col3 value must be greater than 0",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                True,  # write to table
+                False,  # write to temp table
+                SparkExpectationsMiscException,  # expected result
+                3,  # input count
+                2,  # error count
+                1,  # output count
+                None,  # source_agg_result
+                None,  # final_agg_result
+                # final_agg_result
+                None,  # source_query_dq_res
+                [
+                    {
+                        "description": "max of col1 value must be greater than 10",
+                        "rule": "max_col1_threshold",
+                        "rule_type": "query_dq",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                    }
+                ],
+                # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 3, "num_row_dq_rules": 1},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 2,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 2,
+                    },  # dq_rules
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
+                },
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Failed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Failed",
+                },  # status
+        ),
+        (
+                # Test case 20
+                # In this test case, dq run set for query_dq source_query_dq &
+                # final_query_dq(ignore, fail)
+                # with action_if_failed (ignore, fail) for query_dq
+                # collect stats in the test_stats_table, error into error_table
+                spark.createDataFrame(
+                    [
+                        # min of col1 must be greater than 10(ignore) - source_query_dq
+                        # max of col1 must be greater than 100(ignore) - final_query_dq
+                        # min of col3 must be greater than 0(fail) - final_query_dq
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row meets all row_dq_expectations(drop)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # ow doesn't meet row_dq expectation1(drop)
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all row_dq_expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_mod_2",
+                        "column_name": "col3",
+                        "expectation": "(col3 % 2) = 0",
+                        "action_if_failed": "drop",
+                        "tag": "validity",
+                        "description": "col3 mod must equals to 0",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": True,
+                        "error_drop_threshold": "40",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "min_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(select min(col1) from test_final_table_view) > 10",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                        "description": "min of col1 value must be greater than 10",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "max_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(select max(col1) from test_final_table_view) > 100",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                        "description": "max of col1 value must be greater than 100",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "min_col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "(select min(col3) from test_final_table_view) > 0",
+                        "action_if_failed": "fail",
+                        "tag": "validity",
+                        "description": "min of col3 value must be greater than 0",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                True,  # write to table
+                False,  # write to temp table
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),  # expected result
+                3,  # input count
+                1,  # error count
+                2,  # output count
+                None,  # source_agg_result
+                None,  # final_agg_result
+                # final_agg_result
+                [
+                    {
+                        "description": "min of col1 value must be greater than 10",
+                        "rule": "min_col1_threshold",
+                        "rule_type": "query_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                    }
+                ],
+                # source_query_dq_res
+                [
+                    {
+                        "description": "max of col1 value must be greater than 100",
+                        "rule": "max_col1_threshold",
+                        "rule_type": "query_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                    }
+                ],
+                # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 2,
+                        "num_source_query_dq_rules": 1,
+                        "num_query_dq_rules": 3,
+                    },  # dq_rules
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
+                },
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Passed",
+                    "final_query_dq_status": "Passed",
+                },  # status
+        ),
+        (
+                # Test case 21
+                # In this test case, dq run set for query_dq source_query_dq &
+                # final_query_dq(ignore, fail)
+                # with action_if_failed (ignore, fail) for query_dq
+                # collect stats in the test_stats_table, error into error_table & raise the error
+                spark.createDataFrame(
+                    [
+                        # min of col1 must be greater than 10(ignore) - source_query_dq
+                        # max of col1 must be greater than 100(fail) - final_query_dq
+                        # min of col3 must be greater than 0(fail) - final_query_dq
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row meets all row_dq_expectations(drop)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # ow doesn't meet row_dq expectation1(drop)
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all row_dq_expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_mod_2",
+                        "column_name": "col3",
+                        "expectation": "(col3 % 2) = 0",
+                        "action_if_failed": "drop",
+                        "tag": "validity",
+                        "description": "col3 mod must equals to 0",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "10",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "min_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(select min(col1) from test_final_table_view) > 10",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                        "description": "min of col1 value must be greater than 10",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "max_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(select max(col1) from test_final_table_view) > 100",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                        "description": "max of col1 value must be greater than 100",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "min_col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "(select min(col3) from test_final_table_view) > 0",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "min of col3 value must be greater than 0",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                True,  # write to table
+                False,  # write to temp table
+                SparkExpectationsMiscException,  # expected result
+                3,  # input count
+                1,  # error count
+                2,  # output count
+                None,  # source_agg_result
+                None,  # final_agg_result
+                # final_agg_result
+                [
+                    {
+                        "description": "min of col1 value must be greater than 10",
+                        "rule": "min_col1_threshold",
+                        "rule_type": "query_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                    }
+                ],
+                # source_query_dq_res
+                [
+                    {
+                        "description": "max of col1 value must be greater than 100",
+                        "rule": "max_col1_threshold",
+                        "rule_type": "query_dq",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                    }
+                ],
+                # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 2,
+                        "num_source_query_dq_rules": 1,
+                        "num_query_dq_rules": 3,
+                    },  # dq_rules
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
+                },
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Failed",
+                    "source_query_dq_status": "Passed",
+                    "final_query_dq_status": "Failed",
+                },  # status
+        ),
+        (
+                # Test case 22
+                # In this test case, dq run set for query_dq source_query_dq &
+                # final_query_dq(ignore, fail)
+                # with action_if_failed (ignore, fail) for query_dq
+                # collect stats in the test_stats_table, error into error_table & raise the error
+                spark.createDataFrame(
+                    [
+                        # min of col1 must be greater than 10(ignore) - source_query_dq
+                        # max of col1 must be greater than 100(fail) - final_query_dq
+                        # min of col3 must be greater than 0(fail) - final_query_dq
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row meets all row_dq_expectations(drop)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # ow doesn't meet row_dq expectation1(drop)
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all row_dq_expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "agg_dq",
+                        "rule": "col3_max_value",
+                        "column_name": "col3",
+                        "expectation": "max(col3) > 1",
+                        "action_if_failed": "fail",
+                        "tag": "validity",
+                        "description": "col3 mod must equals to 0",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "row_dq",
+                        "rule": "col3_mod_2",
+                        "column_name": "col3",
+                        "expectation": "(col3 % 2) = 0",
+                        "action_if_failed": "drop",
+                        "tag": "validity",
+                        "description": "col3 mod must equals to 0",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "100",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "count_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(select count(col1) from test_final_table_view) > 3",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                        "description": "count of col1 value must be greater than 3",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "col3_positive_threshold",
+                        "column_name": "col1",
+                        "expectation": "(select count(case when col3>0 then 1 else 0 end) from "
+                                       "test_final_table_view) > 10",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                        "description": "count of col3 positive value must be greater than 10",
+                        "enable_for_source_dq_validation": False,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                True,  # write to table
+                False,  # write to temp table
+                spark.createDataFrame(
+                    [
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),  # expected result
+                3,  # input count
+                1,  # error count
+                2,  # output count
+                None,  # source_agg_result
+                None,  # final_agg_result
+                # final_agg_result
+                [
+                    {
+                        "description": "count of col1 value must be greater than 3",
+                        "rule": "count_col1_threshold",
+                        "rule_type": "query_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                    }
+                ],
+                # source_query_dq_res
+                [
+                    {
+                        "description": "count of col3 positive value must be greater than 10",
+                        "rule": "col3_positive_threshold",
+                        "rule_type": "query_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "strict",
+                    }
+                ],
+                # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 4, "num_row_dq_rules": 1},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 1,
+                        "num_source_query_dq_rules": 1,
+                        "num_query_dq_rules": 2,
+                    },  # dq_rules
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 1,
+                        "num_agg_dq_rules": 1,
+                        "num_final_agg_dq_rules": 1,
+                    },
+                },
+                {
+                    "row_dq_status": "Passed",
+                    "source_agg_dq_status": "Passed",
+                    "final_agg_dq_status": "Passed",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Passed",
+                    "final_query_dq_status": "Passed",
+                },  # status
+        ),
+        (
+                # Test case 23
+                # In this test case, dq run set for query_dq source_query_dq and one of the rule is parameterized
+                # with action_if_failed (ignore) for query_dq
+                # collect stats in the test_stats_table & error into error_table
+                spark.createDataFrame(
+                    [
+                        # sum of col1 must be greater than 10(ignore)
+                        # standard deviation of col3 must be greater than 0(ignore)
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        # row doesn't meet row_dq expectation1(drop)
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        # row meets all row_dq_expectations
+                        {"col1": 3, "col2": "c", "col3": 6},
+                        # row meets all row_dq_expectations
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "sum_col1_threshold",
+                        "column_name": "col1",
+                        "expectation": "(select sum(col1) from {table}) > 10",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "sum of col1 value must be greater than 10",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "query_dq",
+                        "rule": "stddev_col3_threshold",
+                        "column_name": "col3",
+                        "expectation": "(select stddev(col3) from test_table) > 0",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                        "description": "stddev of col3 value must be greater than 0",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": True,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    },
+                ],
+                False,  # write to table
+                False,  # write to temp table
+                None,  # expected result
+                3,  # input count
+                0,  # error count
+                0,  # output count
+                None,  # source_agg_result
+                None,  # final_agg_result
+                # final_agg_result
+                [
+                    {
+                        "description": "sum of col1 value must be greater than 10",
+                        "rule": "sum_col1_threshold",
+                        "rule_type": "query_dq",
+                        "action_if_failed": "ignore",
+                        "tag": "validity",
+                    }
+                ],
+                # source_query_dq_res
+                None,  # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 2, "num_row_dq_rules": 0},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 2,
+                        "num_source_query_dq_rules": 2,
+                        "num_query_dq_rules": 2,
+                    },  # dq_rules
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 0,
+                        "num_agg_dq_rules": 0,
+                        "num_final_agg_dq_rules": 0,
+                    },
+                },
+                {
+                    "row_dq_status": "Skipped",
+                    "source_agg_dq_status": "Skipped",
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Passed",
+                    "source_query_dq_status": "Passed",
+                    "final_query_dq_status": "Skipped",
+                },  # status
+        ),
+        (
+                # Test case 24
+                # In this test case, dq run set for source_agg_dq with action_if_failed fail
+                # with the sql syntax > lower_bound and < upper_bound
+                # collect stats in the test_stats_table
+                spark.createDataFrame(
+                    [
+                        # avg of col3 is greater than 18 and not more than 25
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "agg_dq",
+                        "rule": "avg_col3_range",
+                        "column_name": "col3",
+                        "expectation": "avg(col3) > 18 and avg(col3) < 25",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                        "description": "avg col3 value must be greater than 18 and less than 25",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    }
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                SparkExpectationsMiscException,  # excepted result
+                3,  # input count
+                0,  # error count
+                0,  # output count
+                [
+                    {
+                        "description": "avg col3 value must be greater than 18 and less than 25",  # source_agg_result
+                        "rule": "avg_col3_range",
+                        "rule_type": "agg_dq",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                    }
+                ],
+                None,  # final_agg_result
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 1,
+                        "num_agg_dq_rules": 1,
+                        "num_final_agg_dq_rules": 1,
+                    },
+                },  # dq_rules
+                {
+                    "row_dq_status": "Skipped",
+                    "source_agg_dq_status": "Failed",  # status
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Failed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
+                },
+        ),
+        (
+                # Test case 25
+                # In this test case, dq run set for source_agg_dq with action_if_failed fail
+                # with the sql syntax between lower_bound and upper_bound
+                # collect stats in the test_stats_table
+                spark.createDataFrame(
+                    [
+                        # avg of col3 is greater than 18 and not more than 25
+                        {"col1": 1, "col2": "a", "col3": 4},
+                        {"col1": 2, "col2": "b", "col3": 5},
+                        {"col1": 3, "col2": "c", "col3": 6},
+                    ]
+                ),
+                [
+                    {
+                        "product_id": "product1",
+                        "table_name": "dq_spark.test_final_table",
+                        "rule_type": "agg_dq",
+                        "rule": "avg_col3_range",
+                        "column_name": "col3",
+                        "expectation": "avg(col3) between 18 and 25",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                        "description": "avg col3 value must be greater than 18 and less than 25",
+                        "enable_for_source_dq_validation": True,
+                        "enable_for_target_dq_validation": False,
+                        "is_active": True,
+                        "enable_error_drop_alert": False,
+                        "error_drop_threshold": "20",
+                    }
+                ],
+                True,  # write to table
+                True,  # write to temp table
+                SparkExpectationsMiscException,  # excepted result
+                3,  # input count
+                0,  # error count
+                0,  # output count
+                [
+                    {
+                        "description": "avg col3 value must be greater than 18 and less than 25",  # source_agg_result
+                        "rule": "avg_col3_range",
+                        "rule_type": "agg_dq",
+                        "action_if_failed": "fail",
+                        "tag": "strict",
+                    }
+                ],
+                None,  # final_agg_result
+                None,  # source_query_dq_res
+                None,  # final_query_dq_res
+                {
+                    "rules": {"num_dq_rules": 1, "num_row_dq_rules": 0},
+                    "query_dq_rules": {
+                        "num_final_query_dq_rules": 0,
+                        "num_source_query_dq_rules": 0,
+                        "num_query_dq_rules": 0,
+                    },
+                    "agg_dq_rules": {
+                        "num_source_agg_dq_rules": 1,
+                        "num_agg_dq_rules": 1,
+                        "num_final_agg_dq_rules": 1,
+                    },
+                },  # dq_rules
+                {
+                    "row_dq_status": "Skipped",
+                    "source_agg_dq_status": "Failed",  # status
+                    "final_agg_dq_status": "Skipped",
+                    "run_status": "Failed",
+                    "source_query_dq_status": "Skipped",
+                    "final_query_dq_status": "Skipped",
+                },
         ),
     ],
 )
 def test_with_expectations(
-    input_df,
-    expectations,
-    write_to_table,
-    write_to_temp_table,
-    expected_output,
-    input_count,
-    error_count,
-    output_count,
-    source_agg_dq_res,
-    final_agg_dq_res,
-    source_query_dq_res,
-    final_query_dq_res,
-    dq_rules,
-    status,
-    _fixture_create_database,
-    _fixture_local_kafka_topic,
+        input_df,
+        expectations,
+        write_to_table,
+        write_to_temp_table,
+        expected_output,
+        input_count,
+        error_count,
+        output_count,
+        source_agg_dq_res,
+        final_agg_dq_res,
+        source_query_dq_res,
+        final_query_dq_res,
+        dq_rules,
+        status,
+        _fixture_create_database,
+        _fixture_local_kafka_topic,
 ):
     input_df.createOrReplaceTempView("test_table")
 
@@ -2842,14 +2849,14 @@ def test_with_expectations(
 
     if isinstance(expected_output, type) and issubclass(expected_output, Exception):
         with pytest.raises(
-            expected_output,
-            match=r"error occurred while processing spark expectations .*",
+                expected_output,
+                match=r"error occurred while processing spark expectations .*",
         ):
             get_dataset()  # decorated_func()
 
         if (
-            status.get("final_agg_dq_status") == "Failed"
-            or status.get("final_query_dq_status") == "Failed"
+                status.get("final_agg_dq_status") == "Failed"
+                or status.get("final_query_dq_status") == "Failed"
         ):
             try:
                 spark.table("dq_spark.test_final_table")
@@ -2867,8 +2874,8 @@ def test_with_expectations(
 
             result_df = spark.table("dq_spark.test_final_table")
             assert (
-                result_df.orderBy("col2").collect()
-                == expected_output_df.orderBy("col2").collect()
+                    result_df.orderBy("col2").collect()
+                    == expected_output_df.orderBy("col2").collect()
             )
 
             if spark.catalog.tableExists("dq_spark.test_final_table_error"):
@@ -2899,17 +2906,17 @@ def test_with_expectations(
     assert len(stats_table.columns) == 20
 
     assert (
-        spark.read.format("kafka")
-        .option("kafka.bootstrap.servers", "localhost:9092")
-        .option("subscribe", "dq-sparkexpectations-stats")
-        .option("startingOffsets", "earliest")
-        .option("endingOffsets", "latest")
-        .load()
-        .orderBy(col("timestamp").desc())
-        .limit(1)
-        .selectExpr("cast(value as string) as value")
-        .collect()
-        == stats_table.selectExpr("to_json(struct(*)) AS value").collect()
+            spark.read.format("kafka")
+            .option("kafka.bootstrap.servers", "localhost:9092")
+            .option("subscribe", "dq-sparkexpectations-stats")
+            .option("startingOffsets", "earliest")
+            .option("endingOffsets", "latest")
+            .load()
+            .orderBy(col("timestamp").desc())
+            .limit(1)
+            .selectExpr("cast(value as string) as value")
+            .collect()
+            == stats_table.selectExpr("to_json(struct(*)) AS value").collect()
     )
 
     # spark.sql("select * from dq_spark.test_final_table").show(truncate=False)
@@ -2926,11 +2933,11 @@ def test_with_expectations(
 
 @patch("spark_expectations.core.expectations.SparkExpectationsWriter.write_error_stats")
 def test_with_expectations_patch(
-    _write_error_stats,
-    _fixture_create_database,
-    _fixture_spark_expectations,
-    _fixture_df,
-    _fixture_rules_df,
+        _write_error_stats,
+        _fixture_create_database,
+        _fixture_spark_expectations,
+        _fixture_df,
+        _fixture_rules_df,
 ):
     decorated_func = _fixture_spark_expectations.with_expectations(
         "dq_spark.test_final_table",
@@ -2947,10 +2954,10 @@ def test_with_expectations_patch(
 
 
 def test_with_expectations_overwrite_writers(
-    _fixture_create_database,
-    _fixture_spark_expectations,
-    _fixture_df,
-    _fixture_rules_df,
+        _fixture_create_database,
+        _fixture_spark_expectations,
+        _fixture_df,
+        _fixture_rules_df,
 ):
     modified_writer = WrappedDataFrameWriter().mode("overwrite").format("iceberg")
     _fixture_spark_expectations.with_expectations(
@@ -2960,17 +2967,17 @@ def test_with_expectations_overwrite_writers(
     )(Mock(return_value=_fixture_df))
 
     assert (
-        _fixture_spark_expectations._context.get_target_and_error_table_writer_config
-        == modified_writer.build()
+            _fixture_spark_expectations._context.get_target_and_error_table_writer_config
+            == modified_writer.build()
     )
 
 
 def test_with_expectations_dataframe_not_returned_exception(
-    _fixture_create_database,
-    _fixture_spark_expectations,
-    _fixture_df,
-    _fixture_rules_df,
-    _fixture_local_kafka_topic,
+        _fixture_create_database,
+        _fixture_spark_expectations,
+        _fixture_df,
+        _fixture_rules_df,
+        _fixture_local_kafka_topic,
 ):
     partial_func = _fixture_spark_expectations.with_expectations(
         "dq_spark.test_final_table",
@@ -2978,10 +2985,10 @@ def test_with_expectations_dataframe_not_returned_exception(
     )
 
     with pytest.raises(
-        SparkExpectationsMiscException,
-        match=r"error occurred while processing spark expectations error occurred while"
-        r" processing spark "
-        r"expectations due to given dataframe is not type of dataframe",
+            SparkExpectationsMiscException,
+            match=r"error occurred while processing spark expectations error occurred while"
+                  r" processing spark "
+                  r"expectations due to given dataframe is not type of dataframe",
     ):
         # Create a mock object with a rdd return value
         mock_func = Mock(return_value=_fixture_df.rdd)
@@ -2996,7 +3003,7 @@ def test_with_expectations_dataframe_not_returned_exception(
 
 
 def test_with_expectations_exception(
-    _fixture_create_database, _fixture_spark_expectations, _fixture_local_kafka_topic
+        _fixture_create_database, _fixture_spark_expectations, _fixture_local_kafka_topic
 ):
     rules_dict = [
         {
@@ -3033,8 +3040,8 @@ def test_with_expectations_exception(
     )
 
     with pytest.raises(
-        SparkExpectationsMiscException,
-        match=r"error occurred while processing spark expectations .*",
+            SparkExpectationsMiscException,
+            match=r"error occurred while processing spark expectations .*",
     ):
         # Create a mock object with a list return value
         mock_func = Mock(return_value=["apple", "banana", "pineapple", "orange"])
@@ -3050,7 +3057,7 @@ def test_with_expectations_exception(
 
 
 def test_with_expectations_negative_parameter(
-    _fixture_create_database, _fixture_spark_expectations, _fixture_local_kafka_topic
+        _fixture_create_database, _fixture_spark_expectations, _fixture_local_kafka_topic
 ):
     rules_dict = [
         {
@@ -3087,8 +3094,8 @@ def test_with_expectations_negative_parameter(
     )
 
     with pytest.raises(
-        SparkExpectationsMiscException,
-        match=r"error occurred while retrieving rules list from the table 'table2'",
+            SparkExpectationsMiscException,
+            match=r"error occurred while retrieving rules list from the table 'table2'",
     ):
         # Create a mock object with a list return value
         mock_func = Mock(return_value=["apple", "banana", "pineapple", "orange"])
@@ -3108,9 +3115,9 @@ def test_with_expectations_negative_parameter(
 # @patch('spark_expectations.notifications.push.spark_expectations_notify._notification_hook', autospec=True,
 #        spec_set=True)
 def test_error_threshold_breach(
-    # _mock_notification_hook, _mock_spark_expectations_notify,
-    _fixture_create_database,
-    _fixture_local_kafka_topic,
+        # _mock_notification_hook, _mock_spark_expectations_notify,
+        _fixture_create_database,
+        _fixture_local_kafka_topic,
 ):
     input_df = spark.createDataFrame(
         [
@@ -3161,10 +3168,10 @@ def test_error_threshold_breach(
     writer = WrappedDataFrameWriter().mode("append").format("delta")
 
     with patch(
-        "spark_expectations.notifications.push.spark_expectations_notify.SparkExpectationsNotify"
-        ".notify_on_exceeds_of_error_threshold",
-        autospec=True,
-        spec_set=True,
+            "spark_expectations.notifications.push.spark_expectations_notify.SparkExpectationsNotify"
+            ".notify_on_exceeds_of_error_threshold",
+            autospec=True,
+            spec_set=True,
     ) as _mock_notification_hook:
         se = SparkExpectations(
             product_id="product1",
@@ -3201,7 +3208,7 @@ def test_error_threshold_breach(
 
 
 def test_target_table_view_exception(
-    _fixture_create_database, _fixture_local_kafka_topic
+        _fixture_create_database, _fixture_local_kafka_topic
 ):
     rules = [
         {
@@ -3275,8 +3282,8 @@ def test_target_table_view_exception(
         return input_df
 
     with pytest.raises(
-        SparkExpectationsMiscException,
-        match=r"error occurred while processing spark expectations .*",
+            SparkExpectationsMiscException,
+            match=r"error occurred while processing spark expectations .*",
     ):
         get_dataset()  # decorated_func()
 
@@ -3289,7 +3296,7 @@ def test_target_table_view_exception(
 def test_spark_expectations_exception():
     writer = WrappedDataFrameWriter().mode("append").format("parquet")
     with pytest.raises(
-        SparkExpectationsMiscException, match=r"Input rules_df is not of dataframe type"
+            SparkExpectationsMiscException, match=r"Input rules_df is not of dataframe type"
     ):
         SparkExpectations(
             product_id="product1",
@@ -3393,7 +3400,7 @@ def test_delta_bucketby_exception():
         WrappedDataFrameWriter().mode("append").format("delta").bucketBy(10, "a", "b")
     )
     with pytest.raises(
-        SparkExpectationsMiscException,
-        match=r"Bucketing is not supported for delta tables yet",
+            SparkExpectationsMiscException,
+            match=r"Bucketing is not supported for delta tables yet",
     ):
         writer.build()


### PR DESCRIPTION
support if dataframe of instance pyspark.sql.connect.dataframe.Dataframe is passed as input


## Description
Spark Expectations currently fail on databricks runtime 14 and above when dataframe of instance pyspark.sql.connect.dataframe.Dataframe is passed as input.

Updated logic to check for both dataframe instances as either of it can be passed depending on how dataframe is created (read from table, output of a query, read from files)


## Related Issue
https://github.com/Nike-Inc/spark-expectations/issues/106

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Uploaded wheel file generated to Databricks cluster runtime versions 13, 14, & 15 and ran spark expectations job 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
