### PR TITLE
support multiple email recipients

### DIFF
--- a/spark_expectations/notifications/plugins/email.py
+++ b/spark_expectations/notifications/plugins/email.py
@@ -51,7 +51,9 @@ class SparkExpectationsEmailPluginImpl(SparkExpectationsNotification):
                 server.starttls()
                 text = msg.as_string()
                 server.sendmail(
-                    _context.get_mail_from, _context.get_to_mail.split(","), text
+                    _context.get_mail_from,
+                    [email.strip() for email in _context.get_to_mail.split(",")],
+                    text,
                 )
                 server.quit()
 

--- a/spark_expectations/notifications/plugins/email.py
+++ b/spark_expectations/notifications/plugins/email.py
@@ -50,7 +50,9 @@ class SparkExpectationsEmailPluginImpl(SparkExpectationsNotification):
                 )
                 server.starttls()
                 text = msg.as_string()
-                server.sendmail(_context.get_mail_from, _context.get_to_mail, text)
+                server.sendmail(
+                    _context.get_mail_from, _context.get_to_mail.split(","), text
+                )
                 server.quit()
 
                 _log.info("email send successfully")

--- a/tests/notification/plugins/test_email.py
+++ b/tests/notification/plugins/test_email.py
@@ -27,7 +27,7 @@ def test_send_notification_success(_mock_context):
         # assert
         mock_smtp.assert_called_with(_mock_context.get_mail_smtp_server, _mock_context.get_mail_smtp_port)
         mock_smtp().starttls.assert_called()
-        mock_smtp().sendmail.assert_called_with(_mock_context.get_mail_from, _mock_context.get_to_mail,
+        mock_smtp().sendmail.assert_called_with(_mock_context.get_mail_from, _mock_context.get_to_mail.split(","),
                                                 _mock_mltp().as_string())
         mock_smtp().quit.assert_called()
 

--- a/tests/notification/plugins/test_email.py
+++ b/tests/notification/plugins/test_email.py
@@ -10,7 +10,7 @@ def test_send_notification_success(_mock_context):
     email_handler = SparkExpectationsEmailPluginImpl()
     _mock_context.get_enable_mail = True
     _mock_context.get_mail_from = "sender@example.com"
-    _mock_context.get_to_mail = "receiver@example.com"
+    _mock_context.get_to_mail = "receiver1@example.com, receiver2@example.com"
     _mock_context.get_mail_subject = "Test Email"
     _mock_context.get_mail_smtp_server = "mailhost.example.com"
     _mock_context.get_mail_smtp_port = 587
@@ -27,7 +27,7 @@ def test_send_notification_success(_mock_context):
         # assert
         mock_smtp.assert_called_with(_mock_context.get_mail_smtp_server, _mock_context.get_mail_smtp_port)
         mock_smtp().starttls.assert_called()
-        mock_smtp().sendmail.assert_called_with(_mock_context.get_mail_from, _mock_context.get_to_mail.split(","),
+        mock_smtp().sendmail.assert_called_with(_mock_context.get_mail_from, [email.strip() for email in _mock_context.get_to_mail.split(",")],
                                                 _mock_mltp().as_string())
         mock_smtp().quit.assert_called()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Support multiple email recipients
## Description
<!--- Describe your changes in detail -->
In current version of SE, email recipient `get_to_mail` is expected to be a single email address.
The change ensures that if `get_to_mail` contains multiple email addresses separated by commas, they are split into a list of individual email addresses before being passed to the sendmail function. This is necessary because sendmail expects a list of recipient addresses.
## Related Issue
[112](https://github.com/Nike-Inc/spark-expectations/issues/112)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Uploaded wheel file generated to Databricks cluster ran spark expectations job.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1310" alt="se_test_cases" src="https://github.com/user-attachments/assets/b10100a6-3cb2-41f0-9a53-8897c025d769">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
