### PR TITLE
[BUGFIX] avoid toJSON call in SparkExpectationsActions

### DIFF
--- a/spark_expectations/utils/actions.py
+++ b/spark_expectations/utils/actions.py
@@ -328,6 +328,7 @@ class SparkExpectationsActions:
                     )
                 ):
                     for _key, _querydq_query in sub_key_value.items():
+                        _querydq_df = _context.spark.sql(_dq_rule["expectation" + "_" + _key])
                         querydq_output.append(
                             (
                                 _context.get_run_id,
@@ -340,11 +341,7 @@ class SparkExpectationsActions:
                                     [
                                         (
                                             _key,
-                                            _context.spark.sql(
-                                                _dq_rule["expectation" + "_" + _key]
-                                            )
-                                            .toJSON()
-                                            .collect(),
+                                            [row.asDict() for row in _querydq_df.collect()],
                                         )
                                     ]
                                 ),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix bug with spark connect

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#120 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Spark connect does not support .toJSON method

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
