### PR TITLE
feat: source_query_dq_results population for all rules

### DIFF
--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -24,7 +24,7 @@ from spark_expectations.core.exceptions import (
 )
 from spark_expectations.secrets import SparkExpectationsSecretsBackend
 from spark_expectations.notifications.push.alert import SparkExpectationsAlert
-from spark_expectations.utils.udf import remove_empty_maps
+from spark_expectations.utils.udf import remove_passing_status_maps
 from spark_expectations.core.context import SparkExpectationsContext
 from spark_expectations.sinks import _sink_hook
 from spark_expectations.config.user_config import Constants as user_config
@@ -920,7 +920,7 @@ class SparkExpectationsWriter:
             df = (
                 df.withColumn(
                     f"meta_{rule_type}_results",
-                    remove_empty_maps(df[f"meta_{rule_type}_results"]),
+                    remove_passing_status_maps(df[f"meta_{rule_type}_results"]),
                 )
                 .withColumn(
                     self._context.get_run_id_name, lit(self._context.get_run_id)

--- a/spark_expectations/utils/udf.py
+++ b/spark_expectations/utils/udf.py
@@ -14,9 +14,22 @@ def remove_empty_maps(column: Column) -> Column:
     return filter(column, lambda x: size(x) > 0)  # pragma: no cover
 
 
+def remove_passing_status_maps(column: Column) -> Column:
+    """
+    This function takes a column of type array(map(str,str)) and removes maps with passing status from it
+    Args:
+        column: Provide a column of type array(map(str,str))
+
+    Returns:
+           list: returns a Column with items with a passing status removed.
+
+    """
+    return filter(column, lambda x: x.getItem("status") != "pass")  # pragma: no cover
+
+
 def get_actions_list(column: Column) -> Column:
     """
-    This function takes column of type array(map(str,str)) and creates list by picking action_if_failed from dict
+    This function takes column of type array(map(str,str)) and creates list by picking action_if_failed from dict of failed expectations rules.
     Args:
         column: Provide a column of type array(map(str,str))
 
@@ -24,7 +37,7 @@ def get_actions_list(column: Column) -> Column:
            list: returns a column with list of action_if_failed from the set expectations rules
 
     """
-
+    column = remove_passing_status_maps(column)
     action_if_failed = transform(column, lambda x: x["action_if_failed"])
     return when(size(action_if_failed) == 0, array(lit("ignore"))).otherwise(
         action_if_failed

--- a/tests/core/test_expectations.py
+++ b/tests/core/test_expectations.py
@@ -994,6 +994,7 @@ def test_spark_session_initialization():
                     "rule": "sum_col3_threshold",
                     "rule_type": "agg_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "strict",
                 }
             ],
@@ -1064,6 +1065,7 @@ def test_spark_session_initialization():
                     "rule": "avg_col3_threshold",
                     "rule_type": "agg_dq",
                     "action_if_failed": "fail",
+                    "status": "fail",
                     "tag": "strict",
                 }
             ],
@@ -1156,6 +1158,7 @@ def test_spark_session_initialization():
                     "rule": "min_col1_threshold",
                     "rule_type": "agg_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "strict",
                 }
             ],
@@ -1247,6 +1250,7 @@ def test_spark_session_initialization():
                     "rule": "std_col3_threshold",
                     "rule_type": "agg_dq",
                     "action_if_failed": "fail",
+                    "status": "fail",
                     "tag": "strict",
                 }
             ],
@@ -1427,6 +1431,7 @@ def test_spark_session_initialization():
                     "rule": "distinct_col2_threshold",
                     "rule_type": "agg_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "validity",
                 }
             ],
@@ -1539,6 +1544,7 @@ def test_spark_session_initialization():
                     "rule": "avg_col1_threshold",
                     "rule_type": "agg_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "accuracy",
                 }
             ],
@@ -1549,6 +1555,7 @@ def test_spark_session_initialization():
                     "rule": "avg_col1_threshold",
                     "rule_type": "agg_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "accuracy",
                 }
             ],
@@ -1678,6 +1685,15 @@ def test_spark_session_initialization():
                     "rule": "avg_col1_threshold",
                     "rule_type": "agg_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
+                    "tag": "validity",
+                },
+                {
+                    "action_if_failed": "ignore",
+                    "description": "stddev of col3 value must be greater than one",
+                    "rule": "stddev_col3_threshold",
+                    "rule_type": "agg_dq",
+                    "status": "pass",
                     "tag": "validity",
                 }
             ],
@@ -1688,6 +1704,7 @@ def test_spark_session_initialization():
                     "description": "avg of col1 value must be greater than 4",
                     "rule": "avg_col1_threshold",
                     "rule_type": "agg_dq",
+                    "status": "fail",
                     "tag": "validity",
                 },
                 {
@@ -1695,6 +1712,7 @@ def test_spark_session_initialization():
                     "description": "stddev of col3 value must be greater than one",
                     "rule": "stddev_col3_threshold",
                     "rule_type": "agg_dq",
+                    "status": "fail",
                     "tag": "validity",
                 },
             ],
@@ -1789,6 +1807,15 @@ def test_spark_session_initialization():
                     "rule": "sum_col1_threshold",
                     "rule_type": "query_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
+                    "tag": "validity",
+                },
+                {
+                    "action_if_failed": "ignore",
+                    "description": "stddev of col3 value must be greater than 0",
+                    "rule": "stddev_col3_threshold",
+                    "rule_type": "query_dq",
+                    "status": "pass",
                     "tag": "validity",
                 }
             ],
@@ -1903,8 +1930,17 @@ def test_spark_session_initialization():
                     "rule": "max_col1_threshold",
                     "rule_type": "query_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "strict",
-                }
+                },
+                {
+                    "action_if_failed": "ignore",
+                    "description": "min of col3 value must be greater than 0",
+                    "rule": "min_col3_threshold",
+                    "rule_type": "query_dq",
+                    "status": "pass",
+                    "tag": "validity",
+                 },
             ],
             # final_query_dq_res
             {
@@ -1994,6 +2030,7 @@ def test_spark_session_initialization():
                     "description": "min of col1 value must be greater than 10",
                     "rule": "min_col1_threshold",
                     "rule_type": "query_dq",
+                    "status": "fail",
                     "tag": "validity",
                 },
                 {
@@ -2001,6 +2038,7 @@ def test_spark_session_initialization():
                     "description": "stddev of col3 value must be greater than 0",
                     "rule": "stddev_col3_threshold",
                     "rule_type": "query_dq",
+                    "status": "fail",
                     "tag": "validity",
                 },
             ],  # source_query_dq_res
@@ -2110,8 +2148,17 @@ def test_spark_session_initialization():
                     "rule": "max_col1_threshold",
                     "rule_type": "query_dq",
                     "action_if_failed": "fail",
+                    "status": "fail",
                     "tag": "strict",
-                }
+                },
+                {
+                    "action_if_failed": "ignore",
+                    "description": "min of col3 value must be greater than 0",
+                    "rule": "min_col3_threshold",
+                    "rule_type": "query_dq",
+                    "status": "pass",
+                    "tag": "validity",
+                },
             ],
             # final_query_dq_res
             {
@@ -2241,6 +2288,7 @@ def test_spark_session_initialization():
                     "rule": "min_col1_threshold",
                     "rule_type": "query_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "strict",
                 }
             ],
@@ -2251,8 +2299,17 @@ def test_spark_session_initialization():
                     "rule": "max_col1_threshold",
                     "rule_type": "query_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "strict",
-                }
+                },
+                {
+                    'action_if_failed': 'fail',
+                    'description': 'min of col3 value must be greater than 0',
+                    'rule': 'min_col3_threshold',
+                    'rule_type': 'query_dq',
+                    'status': 'pass',
+                    'tag': 'validity',
+                },
             ],
             # final_query_dq_res
             {
@@ -2377,6 +2434,7 @@ def test_spark_session_initialization():
                     "rule": "min_col1_threshold",
                     "rule_type": "query_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "strict",
                 }
             ],
@@ -2387,8 +2445,17 @@ def test_spark_session_initialization():
                     "rule": "max_col1_threshold",
                     "rule_type": "query_dq",
                     "action_if_failed": "fail",
+                    "status": "fail",
                     "tag": "strict",
-                }
+                },
+                {
+                    "action_if_failed": "ignore",
+                    "description": "min of col3 value must be greater than 0",
+                    "rule": "min_col3_threshold",
+                    "rule_type": "query_dq",
+                    "status": "pass",
+                    "tag": "validity",
+                },
             ],
             # final_query_dq_res
             {
@@ -2510,8 +2577,26 @@ def test_spark_session_initialization():
             3,  # input count
             1,  # error count
             2,  # output count
-            None,  # source_agg_result
-            None,  # final_agg_result
+            [
+                {
+                    "action_if_failed": "fail",
+                    "description": "col3 mod must equals to 0",
+                    "rule": "col3_max_value",
+                    "rule_type": "agg_dq",
+                    "status": "pass",
+                    "tag": "validity",
+                }
+            ],  # source_agg_result
+            [
+                {
+                    "action_if_failed": "fail",
+                    "description": "col3 mod must equals to 0",
+                    "rule": "col3_max_value",
+                    "rule_type": "agg_dq",
+                    "status": "pass",
+                    "tag": "validity",
+                }
+            ],  # final_agg_result
             # final_agg_result
             [
                 {
@@ -2519,6 +2604,7 @@ def test_spark_session_initialization():
                     "rule": "count_col1_threshold",
                     "rule_type": "query_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "strict",
                 }
             ],
@@ -2529,6 +2615,7 @@ def test_spark_session_initialization():
                     "rule": "col3_positive_threshold",
                     "rule_type": "query_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "strict",
                 }
             ],
@@ -2621,8 +2708,17 @@ def test_spark_session_initialization():
                     "rule": "sum_col1_threshold",
                     "rule_type": "query_dq",
                     "action_if_failed": "ignore",
+                    "status": "fail",
                     "tag": "validity",
-                }
+                },
+                {
+                    "action_if_failed": "ignore",
+                    "description": "stddev of col3 value must be greater than 0",
+                    "rule": "stddev_col3_threshold",
+                    "rule_type": "query_dq",
+                    "status": "pass",
+                    "tag": "validity",
+                },
             ],
             # source_query_dq_res
             None,  # final_query_dq_res
@@ -2691,6 +2787,7 @@ def test_spark_session_initialization():
                     "rule": "avg_col3_range",
                     "rule_type": "agg_dq",
                     "action_if_failed": "fail",
+                    "status": "fail",
                     "tag": "strict",
                 }
             ],
@@ -2762,6 +2859,7 @@ def test_spark_session_initialization():
                     "rule": "avg_col3_range",
                     "rule_type": "agg_dq",
                     "action_if_failed": "fail",
+                    "status": "fail",
                     "tag": "strict",
                 }
             ],
@@ -2790,7 +2888,7 @@ def test_spark_session_initialization():
                 "final_query_dq_status": "Skipped",
             },
         ),
-    ],
+    ][0:1],
 )
 def test_with_expectations(
     input_df,
@@ -3343,6 +3441,7 @@ def test_se_notifications_on_rules_action_if_failed_set_ignore_sends_notificatio
                     "description": "count of records must be greater than 10",
                     "rule_type": "query_dq",
                     "tag": "strict",
+                    "status": "fail",
                     "action_if_failed": "ignore"
                 },
                 {
@@ -3350,6 +3449,7 @@ def test_se_notifications_on_rules_action_if_failed_set_ignore_sends_notificatio
                     "description": "desc_sum_of_value_should_be_less_than_60",
                     "rule_type": "agg_dq",
                     "tag": "strict",
+                    "status": "fail",
                     "action_if_failed": "ignore"
                 },
                 {
@@ -3357,6 +3457,7 @@ def test_se_notifications_on_rules_action_if_failed_set_ignore_sends_notificatio
                     "description": "count of records must be greater than 10",
                     "rule_type": "query_dq",
                     "tag": "strict",
+                    "status": "fail",
                     "action_if_failed": "ignore"
                 },
                 {
@@ -3364,6 +3465,7 @@ def test_se_notifications_on_rules_action_if_failed_set_ignore_sends_notificatio
                     "description": "desc_sum_of_value_should_be_less_than_60",
                     "rule_type": "agg_dq",
                     "tag": "strict",
+                    "status": "fail",
                     "action_if_failed": "ignore"
                 }
             ]

--- a/tests/core/test_expectations.py
+++ b/tests/core/test_expectations.py
@@ -2888,7 +2888,7 @@ def test_spark_session_initialization():
                 "final_query_dq_status": "Skipped",
             },
         ),
-    ][0:1],
+    ],
 )
 def test_with_expectations(
     input_df,

--- a/tests/sinks/utils/test_writer.py
+++ b/tests/sinks/utils/test_writer.py
@@ -200,10 +200,10 @@ def fixture_create_stats_table():
 def fixture_dq_dataset():
     return spark.createDataFrame(
         [
-            (1, "a", {"id": "1", "rule": "rule1"}, {}),
+            (1, "a", {"id": "1", "rule": "rule1", "status": "fail"}, {}),
             (2, "b", {}, {}),
-            (3, "c", {"id": "3", "rule": "rule1"}, {"name": "c", "rule": "rule2"}),
-            (4, "d", {}, {"name": "d", "rule": "rule2"}),
+            (3, "c", {"id": "3", "rule": "rule1", "status": "fail"}, {"name": "c", "rule": "rule2", "status": "fail"}),
+            (4, "d", {}, {"name": "d", "rule": "rule2", "status": "fail"}),
         ],
         ["id", "name", "row_dq_id", "row_dq_name"],
     )
@@ -214,14 +214,14 @@ def fixture_expected_error_dataset():
     spark.conf.set("spark.sql.session.timeZone", "Etc/UTC")
     return spark.createDataFrame(
         [
-            (1, "a", [{"id": "1", "rule": "rule1"}], "product1_run_test"),
+            (1, "a", [{"id": "1", "rule": "rule1", "status": "fail"}], "product1_run_test"),
             (
                 3,
                 "c",
-                [{"id": "3", "rule": "rule1"}, {"name": "c", "rule": "rule2"}],
+                [{"id": "3", "rule": "rule1", "status": "fail"}, {"name": "c", "rule": "rule2", "status": "fail"}],
                 "product1_run_test",
             ),
-            (4, "d", [{"name": "d", "rule": "rule2"}], "product1_run_test"),
+            (4, "d", [{"name": "d", "rule": "rule2", "status": "fail"}], "product1_run_test"),
         ],
         ["id", "name", "meta_row_dq_results", "run_id"],
     ).withColumn("meta_dq_run_date", to_timestamp(lit("2022-12-27 10:39:44")))
@@ -232,15 +232,15 @@ def fixture_expected_dq_dataset():
     spark.conf.set("spark.sql.session.timeZone", "Etc/UTC")
     return spark.createDataFrame(
         [
-            (1, "a", [{"id": "1", "rule": "rule1"}], "product1_run_test"),
+            (1, "a", [{"id": "1", "rule": "rule1", "status": "fail"}], "product1_run_test"),
             (2, "b", [], "product1_run_test"),
             (
                 3,
                 "c",
-                [{"id": "3", "rule": "rule1"}, {"name": "c", "rule": "rule2"}],
+                [{"id": "3", "rule": "rule1", "status": "fail"}, {"name": "c", "rule": "rule2", "status": "fail"}],
                 "product1_run_test",
             ),
-            (4, "d", [{"name": "d", "rule": "rule2"}], "product1_run_test"),
+            (4, "d", [{"name": "d", "rule": "rule2", "status": "fail"}], "product1_run_test"),
         ],
         ["id", "name", "meta_row_dq_results", "meta_dq_run_id"],
     ).withColumn("meta_dq_run_date", to_timestamp(lit("2022-12-27 10:39:44")))

--- a/tests/utils/test_actions.py
+++ b/tests/utils/test_actions.py
@@ -335,37 +335,82 @@ def fixture_row_dq_expected_result():
     return {
         "result": [
             {
-                "row_dq_col1_gt_eq_1": {},
+                "row_dq_col1_gt_eq_1": {
+                    "action_if_failed": "ignore",
+                    "description": "col1 gt or eq 1",
+                    "rule": "col1_gt_eq_1",
+                    "rule_type": "row_dq",
+                    "status": "pass",
+                    "tag": "validity",
+                },
                 "row_dq_col1_gt_eq_2": {
                     "rule_type": "row_dq",
                     "rule": "col1_gt_eq_2",
                     "action_if_failed": "drop",
+                    "status": "fail",
                     "tag": "accuracy",
                     "description": "col1 gt or eq 2"
                 },
                 "row_dq_col1_gt_eq_3": {"rule_type": "row_dq",
                                         "rule": "col1_gt_eq_3",
                                         "action_if_failed": "fail",
+                                        "status": "fail",
                                         "tag": "completeness",
                                         "description": "col1 gt or eq 3"
                                         }
             },
 
             {
-                "row_dq_col1_gt_eq_1": {},
-                "row_dq_col1_gt_eq_2": {},
+                "row_dq_col1_gt_eq_1": {
+                    "action_if_failed": "ignore",
+                    "description": "col1 gt or eq 1",
+                    "rule": "col1_gt_eq_1",
+                    "rule_type": "row_dq",
+                    "status": "pass",
+                    "tag": "validity",
+                },
+                "row_dq_col1_gt_eq_2": {
+                    "rule_type": "row_dq",
+                    "rule": "col1_gt_eq_2",
+                    "action_if_failed": "drop",
+                    "status": "pass",
+                    "tag": "accuracy",
+                    "description": "col1 gt or eq 2"
+                },
                 "row_dq_col1_gt_eq_3": {"rule_type": "row_dq",
                                         "rule": "col1_gt_eq_3",
                                         "action_if_failed": "fail",
+                                        "status": "fail",
                                         "tag": "completeness",
                                         "description": "col1 gt or eq 3"
                                         }
             },
 
             {
-                "row_dq_col1_gt_eq_1": {},
-                "row_dq_col1_gt_eq_2": {},
-                "row_dq_col1_gt_eq_3": {}
+                "row_dq_col1_gt_eq_1": {
+                    "action_if_failed": "ignore",
+                    "description": "col1 gt or eq 1",
+                    "rule": "col1_gt_eq_1",
+                    "rule_type": "row_dq",
+                    "status": "pass",
+                    "tag": "validity",
+                },
+                "row_dq_col1_gt_eq_2": {
+                    "rule_type": "row_dq",
+                    "rule": "col1_gt_eq_2",
+                    "action_if_failed": "drop",
+                    "status": "pass",
+                    "tag": "accuracy",
+                    "description": "col1 gt or eq 2"
+                },
+                "row_dq_col1_gt_eq_3": {
+                    "rule_type": "row_dq",
+                    "rule": "col1_gt_eq_3",
+                    "action_if_failed": "fail",
+                    "status": "pass",
+                    "tag": "completeness",
+                    "description": "col1 gt or eq 3"
+                }
             }
 
         ]}
@@ -376,17 +421,28 @@ def fixture_agg_dq_expected_result():
     # define the expected result for agg dq operations
     return {
         "result":
-            [{
-                "rule_type": "agg_dq",
-                "rule": "col2_unique_value_gt_3",
-                "action_if_failed": "fail",
-                "tag": "accuracy",
-                "description": "col2 unique value grater than 3"
-            },
+            [
+                {
+                    "action_if_failed": "ignore",
+                    "description": "col1 sum gt 1",
+                    "rule": "col1_sum_gt_eq_6",
+                    "rule_type": "agg_dq",
+                    "status": "pass",
+                    "tag": "validity",
+                },
+                {
+                    "rule_type": "agg_dq",
+                    "rule": "col2_unique_value_gt_3",
+                    "action_if_failed": "fail",
+                    "status": "fail",
+                    "tag": "accuracy",
+                    "description": "col2 unique value grater than 3"
+                },
                 {
                     "rule_type": "agg_dq",
                     "rule": "col1_sum_gt_6_and_lt_10",
                     "action_if_failed": "fail",
+                    "status": "fail",
                     "tag": "accuracy",
                     "description": "sum of col1 value grater than 6 and less than 10"
                 }
@@ -404,6 +460,7 @@ def fixture_query_dq_expected_result():
                     'rule': 'table_row_count_gt_1',
                     'description': 'table count should be greater than 1',
                     'rule_type': 'query_dq',
+                    "status": "fail",
                     'tag': 'validity',
                     'action_if_failed': 'ignore'
                 },
@@ -411,6 +468,7 @@ def fixture_query_dq_expected_result():
                     'rule': 'table_distinct_count',
                     'description': 'table distinct row count should be greater than 3',
                     'rule_type': 'query_dq',
+                    "status": "fail",
                     'tag': 'accuracy',
                     'action_if_failed': 'fail'
                 }
@@ -912,12 +970,12 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # function should return dataframe with all the rows
                 spark.createDataFrame(
                     [  # drop & log into error
-                        {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "drop"},
-                                                                         {"action_if_failed": "drop"},
-                                                                         {"action_if_failed": "drop"}]},
+                        {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "drop", "status": "fail"},
+                                                                         {"action_if_failed": "drop", "status": "fail"},
+                                                                         {"action_if_failed": "drop", "status": "fail"}]},
                         # drop & log into error
                         {"col1": 2, "col2": "b", "meta_row_dq_results": [
-                            {"action_if_failed": "drop"}]},
+                            {"action_if_failed": "drop", "status": "fail"}]},
                         # log into final
                         {"col1": 3, "col2": "c", "meta_row_dq_results": []}
                     ]
@@ -944,9 +1002,9 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # spark expectations expected to fail
                 spark.createDataFrame(
                     [  # log into error and raise error
-                        {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "fail"},
-                                                                         {"action_if_failed": "fail"},
-                                                                         {"action_if_failed": "fail"}]},
+                        {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "fail", "status": "fail"},
+                                                                         {"action_if_failed": "fail", "status": "fail"},
+                                                                         {"action_if_failed": "fail", "status": "fail"}]},
                         {"col1": 2, "col2": "b", "meta_row_dq_results": []},
                         {"col1": 3, "col2": "c", "meta_row_dq_results": []}
                     ]
@@ -970,14 +1028,14 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 spark.createDataFrame(
                     [
                         # drop, log into error
-                        {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "ignore"},
-                                                                         {"action_if_failed": "ignore"},
-                                                                         {"action_if_failed": "drop"}]},
+                        {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "ignore", "status": "fail"},
+                                                                         {"action_if_failed": "ignore", "status": "fail"},
+                                                                         {"action_if_failed": "drop", "status": "fail"}]},
                         # log into error and final
-                        {"col1": 2, "col2": "b", "meta_row_dq_results": [{"action_if_failed": "ignore"}]},
+                        {"col1": 2, "col2": "b", "meta_row_dq_results": [{"action_if_failed": "ignore", "status": "fail"}]},
                         # log into error and final
                         {"col1": 2, "col2": "c", "meta_row_dq_results": [
-                            {"action_if_failed": "ignore"}]}
+                            {"action_if_failed": "ignore", "status": "fail"}]}
                     ]
                 ),
                 'test_dq_stats_table',  # table name
@@ -1004,12 +1062,12 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 spark.createDataFrame(
                     [
                         # log into to error & fail program
-                        {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "ignore"},
-                                                                         {"action_if_failed": "ignore"}
-                            , {"action_if_failed": "fail"}]},
+                        {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "ignore", "status": "fail"},
+                                                                         {"action_if_failed": "ignore", "status": "fail"}
+                            , {"action_if_failed": "fail", "status": "fail"}]},
                         # log into error
                         {"col1": 2, "col2": "b",
-                         "meta_row_dq_results": [{"action_if_failed": "ignore"}]},
+                         "meta_row_dq_results": [{"action_if_failed": "ignore", "status": "fail"}]},
                         {"col1": 3, "col2": "c", "meta_row_dq_results": []}
                     ]
                 ),
@@ -1031,11 +1089,11 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
         (spark.createDataFrame(
             [
                 # log into error & fail
-                {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "drop"},
-                                                                 {"action_if_failed": "drop"},
-                                                                 {"action_if_failed": "fail"}]},
+                {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "drop", "status": "fail"},
+                                                                 {"action_if_failed": "drop", "status": "fail"},
+                                                                 {"action_if_failed": "fail", "status": "fail"}]},
                 # log into error & drop
-                {"col1": 2, "col2": "b", "meta_row_dq_results": [{"action_if_failed": "drop"}]},
+                {"col1": 2, "col2": "b", "meta_row_dq_results": [{"action_if_failed": "drop", "status": "fail"}]},
                 {"col1": 3, "col2": "c", "meta_row_dq_results": []}
             ]
         ),
@@ -1059,12 +1117,12 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 spark.createDataFrame(
                     [
                         # drop and log into error
-                        {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "drop"},
-                                                                         {"action_if_failed": "ignore"},
-                                                                         {"action_if_failed": "ignore"}]},
+                        {"col1": 1, "col2": "a", "meta_row_dq_results": [{"action_if_failed": "drop", "status": "fail"},
+                                                                         {"action_if_failed": "ignore", "status": "fail"},
+                                                                         {"action_if_failed": "ignore", "status": "fail"}]},
                         # log into final
                         {"col1": 2, "col2": "b", "meta_row_dq_results":
-                            [{"action_if_failed": "test"}]},
+                            [{"action_if_failed": "test", "status": "fail"}]},
                         # log into final
                         {"col1": 3, "col2": "c", "meta_row_dq_results": []}
                     ]
@@ -1111,7 +1169,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # function returns empty dataframe
                 spark.createDataFrame(
                     [
-                        {"meta_agg_dq_results": [{"action_if_failed": "ignore"}]},
+                        {"meta_agg_dq_results": [{"action_if_failed": "ignore", "status": "fail"}]},
                     ]
                 ),
                 'test_dq_stats_table',  # table name
@@ -1125,7 +1183,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 False,  # source_query_dq_flag
                 False,  # final_query_dq_flag
                 # expected df
-                spark.createDataFrame([{"meta_agg_dq_results": [{"action_if_failed": "ignore"}]}]).drop(
+                spark.createDataFrame([{"meta_agg_dq_results": [{"action_if_failed": "ignore", "status": "fail"}]}]).drop(
                     "meta_agg_dq_results")
         ),
         (
@@ -1134,7 +1192,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # function returns empty dataframe
                 spark.createDataFrame(
                     [
-                        {"meta_agg_dq_results": [{"action_if_failed": "fail"}]},
+                        {"meta_agg_dq_results": [{"action_if_failed": "fail", "status": "fail"}]},
                     ]
                 ),
                 'test_dq_stats_table',  # table name
@@ -1155,7 +1213,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # function returns empty dataframe
                 spark.createDataFrame(
                     [
-                        {"meta_agg_dq_results": [{"action_if_failed": "ignore"}]},
+                        {"meta_agg_dq_results": [{"action_if_failed": "ignore", "status": "fail"}]},
                     ]
                 ),
                 'test_dq_stats_table',  # table name
@@ -1171,7 +1229,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # expected df
                 spark.createDataFrame(
                     [
-                        {"meta_agg_dq_results": [{"action_if_failed": "ignore"}]},
+                        {"meta_agg_dq_results": [{"action_if_failed": "ignore", "status": "fail"}]},
                     ]
                 ).drop("meta_agg_dq_results")
         ),
@@ -1181,7 +1239,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # spark expectations set to fail for agg_dq on final_agg-dq
                 spark.createDataFrame(
                     [
-                        {"meta_agg_dq_results": [{"action_if_failed": "fail"}]},
+                        {"meta_agg_dq_results": [{"action_if_failed": "fail", "status": "fail"}]},
                     ]
                 ),
                 'test_dq_stats_table',  # table name
@@ -1203,7 +1261,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # spark expectations set to fail for agg_dq on final_agg_dq
                 spark.createDataFrame(
                     [
-                        {"meta_agg_dq_results": [{"action_if_failed": "fail"}]},
+                        {"meta_agg_dq_results": [{"action_if_failed": "fail", "status": "fail"}]},
                     ]
                 ),
                 'test_dq_stats_table',  # table name
@@ -1225,8 +1283,8 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # spark expectations set to fail for agg_dq on final_agg_dq
                 spark.createDataFrame(
                     [
-                        {"meta_agg_dq_results": [{"action_if_failed": "ignore"},
-                                                 {"action_if_failed": "fail"}]},
+                        {"meta_agg_dq_results": [{"action_if_failed": "ignore", "status": "fail"},
+                                                 {"action_if_failed": "fail", "status": "fail"}]},
                     ]
                 ),
                 'test_dq_stats_table',  # table name
@@ -1248,8 +1306,8 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # function returns a empty datatset
                 spark.createDataFrame(
                     [
-                        {"meta_agg_dq_results": [{"action_if_failed": "ignore"},
-                                                 {"action_if_failed": "ignore"}]},
+                        {"meta_agg_dq_results": [{"action_if_failed": "ignore", "status": "fail"},
+                                                 {"action_if_failed": "ignore", "status": "fail"}]},
                     ]
                 ),
                 'test_dq_stats_table',  # table name
@@ -1264,7 +1322,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 False,  # final_query_dq_flag
                 spark.createDataFrame(
                     [
-                        {"meta_agg_dq_results": [{"action_if_failed": "ignore"}]},
+                        {"meta_agg_dq_results": [{"action_if_failed": "ignore", "status": "fail"}]},
                     ]
                 ).drop("meta_agg_dq_results")  # expected df
         ),
@@ -1275,9 +1333,9 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # function returns a empty datatset
                 spark.createDataFrame(
                     [
-                        {"meta_agg_dq_results": [{"action_if_failed": "ignore"},
-                                                 {"action_if_failed": "ignore"},
-                                                 {"action_if_failed": "ignore"}]},
+                        {"meta_agg_dq_results": [{"action_if_failed": "ignore", "status": "fail"},
+                                                 {"action_if_failed": "ignore", "status": "fail"},
+                                                 {"action_if_failed": "ignore", "status": "fail"}]},
                     ]
                 ),
                 'test_dq_stats_table',  # table name
@@ -1292,7 +1350,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 False,  # final_query_dq_flag
                 spark.createDataFrame(
                     [
-                        {"meta_agg_dq_results": [{"action_if_failed": "ignore"}]},
+                        {"meta_agg_dq_results": [{"action_if_failed": "ignore", "status": "fail"}]},
                     ]
                 ).drop("meta_agg_dq_results")  # expected df
         ),
@@ -1302,9 +1360,9 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # function returns a empty datatset
                 spark.createDataFrame(
                     [
-                        {"meta_query_dq_results": [{"action_if_failed": "ignore"},
-                                                   {"action_if_failed": "ignore"},
-                                                   {"action_if_failed": "ignore"}]},
+                        {"meta_query_dq_results": [{"action_if_failed": "ignore", "status": "fail"},
+                                                   {"action_if_failed": "ignore", "status": "fail"},
+                                                   {"action_if_failed": "ignore", "status": "fail"}]},
                     ]
                 ),
                 'test_dq_stats_table',  # table name
@@ -1319,7 +1377,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 False,  # final_query_dq_flag
                 spark.createDataFrame(
                     [
-                        {"meta_query_dq_results": [{"action_if_failed": "ignore"}]},
+                        {"meta_query_dq_results": [{"action_if_failed": "ignore", "status": "fail"}]},
                     ]
                 ).drop("meta_query_dq_results")  # expected df
         ),
@@ -1329,11 +1387,11 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 # function set to fail with exceptions
                 spark.createDataFrame(
                     [
-                        {"meta_query_dq_results": [{"action_if_failed": "ignore"},
-                                                   {"action_if_failed": "fail"},
-                                                   {"action_if_failed": "ignore"},
-                                                   {"action_if_failed": "ignore"},
-                                                   {"action_if_failed": "ignore"}
+                        {"meta_query_dq_results": [{"action_if_failed": "ignore", "status": "fail"},
+                                                   {"action_if_failed": "fail", "status": "fail"},
+                                                   {"action_if_failed": "ignore", "status": "fail"},
+                                                   {"action_if_failed": "ignore", "status": "fail"},
+                                                   {"action_if_failed": "ignore", "status": "fail"}
 
                                                    ]},
                     ]
@@ -1357,7 +1415,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 spark.createDataFrame(
                     [
                         {"meta_query_dq_results": [
-                            {"action_if_failed": "fail"},
+                            {"action_if_failed": "fail", "status": "fail"},
                         ]},
                     ]
                 ),
@@ -1380,7 +1438,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 spark.createDataFrame(
                     [
                         {"meta_query_dq_results": [
-                            {"action_if_failed": "ignore"},
+                            {"action_if_failed": "ignore", "status": "fail"},
                         ]},
                     ]
                 ),
@@ -1396,7 +1454,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 True,  # final_query_dq_flag
                 spark.createDataFrame(
                     [
-                        {"meta_query_dq_results": [{"action_if_failed": "ignore"}]},
+                        {"meta_query_dq_results": [{"action_if_failed": "ignore", "status": "fail"}]},
                     ]
                 ).drop("meta_query_dq_results")  # expected df
         ),
@@ -1407,12 +1465,12 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 spark.createDataFrame(
                     [
                         {"meta_query_dq_results": [
-                            {"action_if_failed": "ignore"},
-                            {"action_if_failed": "ignore"},
-                            {"action_if_failed": "ignore"},
-                            {"action_if_failed": "ignore"},
-                            {"action_if_failed": "ignore"},
-                            {"action_if_failed": "ignore"}
+                            {"action_if_failed": "ignore", "status": "fail"},
+                            {"action_if_failed": "ignore", "status": "fail"},
+                            {"action_if_failed": "ignore", "status": "fail"},
+                            {"action_if_failed": "ignore", "status": "fail"},
+                            {"action_if_failed": "ignore", "status": "fail"},
+                            {"action_if_failed": "ignore", "status": "fail"}
                         ]},
                     ]
                 ),
@@ -1428,7 +1486,7 @@ def test_run_dq_rules_negative_case(_fixture_df, _fixture_mock_context):
                 True,  # final_query_dq_flag
                 spark.createDataFrame(
                     [
-                        {"meta_query_dq_results": [{"action_if_failed": "ignore"}]},
+                        {"meta_query_dq_results": [{"action_if_failed": "ignore", "status": "fail"}]},
                     ]
                 ).drop("meta_query_dq_results")  # expected df
         )

--- a/tests/utils/test_regulate_flow.py
+++ b/tests/utils/test_regulate_flow.py
@@ -609,7 +609,16 @@ def fixture_create_stats_table():
                                      True,  # write to table
                                      # expected df
                                      spark.createDataFrame([{"col1": 1}]).drop("col1"),
-                                     None,  # expected agg dq result
+                                     [
+                                         {
+                                            "action_if_failed": "ignore",
+                                            "description": "sum of col3 value must be greater than 1",
+                                            "rule": "sum_col3_threshold",
+                                            "rule_type": "agg_dq",
+                                            "status": "pass",
+                                            "tag": "validity",
+                                        },
+                                     ],  # expected agg dq result
                                      # status at different stages for given input
                                      {"row_dq_status": "Skipped", "source_agg_dq_status": "Passed",
                                       "final_agg_dq_status": "Skipped", "run_status": "Passed",
@@ -706,7 +715,7 @@ def fixture_create_stats_table():
                                      # expected agg dq result
                                      [{"description": "distinct of col2 value must be greater than 4",
                                        "rule": "distinct_col2_threshold",
-                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "tag": "validity"}],
+                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "status": "fail", "tag": "validity"}],
                                      # status at different stages for given input
                                      {"row_dq_status": "Skipped", "source_agg_dq_status": "Passed",
                                       "final_agg_dq_status": "Skipped", "run_status": "Passed",
@@ -752,7 +761,16 @@ def fixture_create_stats_table():
                                      0,  # output count
                                      True,  # write to table
                                      None,  # expected res df
-                                     None,  # expected agg dq result
+                                     [
+                                        {
+                                            "action_if_failed": "ignore",
+                                            "description": "min of col3 value must be greater than 1",
+                                            "rule": "min_col3_threshold",
+                                            "rule_type": "agg_dq",
+                                            "status": "pass",
+                                            "tag": "validity",
+                                        },
+                                     ],  # expected agg dq result
                                      # status at different stages for given input
                                      {"row_dq_status": "Skipped", "source_agg_dq_status": "Passed",
                                       "final_agg_dq_status": "Passed", "run_status": "Passed",
@@ -844,7 +862,7 @@ def fixture_create_stats_table():
                                      # expected agg dq result
                                      [{"description": "average of col1 value must be greater than 25",
                                        "rule": "avg_col2_threshold",
-                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "tag": "validity"}],
+                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "status": "fail", "tag": "validity"}],
                                      # status at different stages for given input
                                      {"row_dq_status": "Skipped", "source_agg_dq_status": "Skipped",
                                       "final_agg_dq_status": "Passed", "run_status": "Passed",
@@ -922,13 +940,13 @@ def fixture_create_stats_table():
                                      # expected agg dq result
                                      [{"description": "average of col1 value must be greater than 25",
                                        "rule": "avg_col1_threshold",
-                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "tag": "validity"},
+                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "status": "fail", "tag": "validity"},
                                       {"description": "min of col3 value must be greater than 15",
                                        "rule": "min_col3_threshold",
-                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "tag": "accuracy"},
+                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "status": "fail", "tag": "accuracy"},
                                       {"description": "distinct count of col2 value must be greater than 5",
                                        "rule": "count_col2_threshold",
-                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "tag": "validity"}
+                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "status": "fail", "tag": "validity"}
                                       ],
                                      # status at different stages for given input
                                      {"row_dq_status": "Skipped", "source_agg_dq_status": "Passed",
@@ -1006,13 +1024,13 @@ def fixture_create_stats_table():
                                      # expected agg dq result
                                      [{"description": "average of col1 value must be greater than 25",
                                        "rule": "avg_col1_threshold",
-                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "tag": "validity"},
+                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "status": "fail", "tag": "validity"},
                                       {"description": "min of col3 value must be greater than 15",
                                        "rule": "min_col3_threshold",
-                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "tag": "validity"},
+                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "status": "fail", "tag": "validity"},
                                       {"description": "distinct count of col2 value must be greater than 5",
                                        "rule": "count_col2_threshold",
-                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "tag": "accuracy"}
+                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "status": "fail", "tag": "accuracy"}
                                       ],
                                      # status at different stages for given input
                                      {"row_dq_status": "Skipped", "source_agg_dq_status": "Passed",
@@ -1090,10 +1108,10 @@ def fixture_create_stats_table():
                                      # expected agg dq result
                                      [{"description": "average of col1 value must be greater than 25",
                                        "rule": "avg_col1_threshold",
-                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "tag": "validity"},
+                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "status": "fail", "tag": "validity"},
                                       {"description": "min of col3 value must be greater than 15",
                                        "rule": "min_col3_threshold",
-                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "tag": "validity"}
+                                       "rule_type": "agg_dq", "action_if_failed": "ignore", "status": "fail", "tag": "validity"}
                                       ],
                                      # status at different stages for given input
                                      {"row_dq_status": "Skipped", "source_agg_dq_status": "Failed",
@@ -1167,7 +1185,32 @@ def fixture_create_stats_table():
                                      3,  # output count
                                      True,  # write to table
                                      None,  # expected res
-                                     None,  # expected agg dq result
+                                     [
+                                        {
+                                            "action_if_failed": "fail",
+                                            "description": "average of col1 value must be less than 25",
+                                            "rule": "avg_col1_threshold",
+                                            "rule_type": "agg_dq",
+                                            "status": "pass",
+                                            "tag": "validity",
+                                        },
+                                        {
+                                            "action_if_failed": "ignore",
+                                            "description": "min of col3 value must be less than 15",
+                                            "rule": "min_col3_threshold",
+                                            "rule_type": "agg_dq",
+                                            "status": "pass",
+                                            "tag": "validity",
+                                        },
+                                        {
+                                            "action_if_failed": "fail",
+                                            "description": "distinct count of col2 value must be greater than 2",
+                                            "rule": "count_col2_threshold",
+                                            "rule_type": "agg_dq",
+                                            "status": "pass",
+                                            "tag": "validity",
+                                        },
+                                    ],  # expected agg dq result
                                      # status at different stages for given input
                                      {"row_dq_status": "Skipped", "source_agg_dq_status": "Skipped",
                                       "final_agg_dq_status": "Passed", "run_status": "Passed"}

--- a/tests/utils/test_udf.py
+++ b/tests/utils/test_udf.py
@@ -27,12 +27,12 @@ def test_remove_empty_maps():
 def test_get_actions_list():
     # Create a test DataFrame
     data = [
-        (1, [{"action_if_failed": "drop", "other_key": "value1"},
-             {"action_if_failed": "ignore", "other_key": "value2"}]),
-        (2, [{"action_if_failed": "ignore", "other_key": "value3"}]),
+        (1, [{"action_if_failed": "drop", "status": "fail", "other_key": "value1"},
+             {"action_if_failed": "ignore", "status": "fail", "other_key": "value2"}]),
+        (2, [{"action_if_failed": "ignore", "status": "fail", "other_key": "value3"}]),
         (3, []),
-        (4, [{"action_if_failed": "ignore", "other_key": "value4"},
-             {"action_if_failed": "fail", "other_key": "value5"}])
+        (4, [{"action_if_failed": "ignore", "status": "fail", "other_key": "value4"},
+             {"action_if_failed": "fail", "status": "fail", "other_key": "value5"}])
     ]
     df = spark.createDataFrame(data, ["id", "dq_res"])
 


### PR DESCRIPTION
## Description
source_query_dq_results will only be populated for failed query_dq rules, and all rules (both failed and succeeded) need to be populated.

## Related Issue
https://github.com/Nike-Inc/spark-expectations/issues/133

## Motivation and Context
Users of this tool need access to all the rules run when expectations runs, so they can build validation dashboards off of the results.

### NOTE ###
This _may_ be a breaking change if folks are expecting to read the results from this column to determine if a rule failed based on the presence of an entry here.

## How Has This Been Tested
Ran in a dev environment and verified the new behavior.

## Screenshots (if appropriate):
This is the new behavior - all query rules run are now output in the results, along with a property indicating the status of if the rule passed or failed.
<img width="353" alt="Screenshot 2025-04-14 at 9 11 14 AM" src="https://github.com/user-attachments/assets/84aca9d4-ae17-45b7-8b26-4087e33c18d9" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)