### PR TITLE
fix: use pkg_resource and spark df

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -399,4 +399,4 @@ enable = ["logging-not-lazy", "c-extension-no-member"]
 notes = ["FIXME", "TODO"]
 
 [tool.pylint.refactoring]
-max-nested-blocks = 3
+max-nested-blocks = 5

--- a/spark_expectations/examples/read_example_dataset.py
+++ b/spark_expectations/examples/read_example_dataset.py
@@ -1,43 +1,58 @@
-import os
-import pandas as pd
-import numpy as np
 import pkg_resources
 from pyspark.sql import DataFrame
 from spark_expectations.core import get_spark_session
+from typing import Optional
 
 spark = get_spark_session()
 
 
-def spark_expectations_read_employee_dataset() -> DataFrame:
-    _df: DataFrame = pd.read_csv(
-        pkg_resources.resource_filename("spark_expectations", "examples/resources/employee.csv")
-    ).replace({np.nan: None})
-
-    return spark.createDataFrame(_df)
-
-
-def spark_expectations_read_order_dataset() -> DataFrame:
-    _df: DataFrame = (
+def spark_expectations_read_employee_dataset(prepend: Optional[str] = None) -> DataFrame:
+    return (
         spark.read.option("header", "true")
         .option("inferSchema", "true")
-        .csv("file://" + os.path.join(os.path.dirname(__file__), "resources/order.csv"))
+        .option("mode", "DROPMALFORMED")
+        .csv(prepend_csv_path(csv_filename="employee.csv", prepend=prepend))
     )
-    return _df
 
 
-def spark_expectations_read_product_dataset() -> DataFrame:
-    _df: DataFrame = (
+def spark_expectations_read_order_dataset(prepend: Optional[str] = None) -> DataFrame:
+    return (
         spark.read.option("header", "true")
         .option("inferSchema", "true")
-        .csv("file://" + os.path.join(os.path.dirname(__file__), "resources/product.csv"))
+        .option("mode", "DROPMALFORMED")
+        .csv(prepend_csv_path(csv_filename="order.csv", prepend=prepend))
     )
-    return _df
 
 
-def spark_expectations_read_customer_dataset() -> DataFrame:
-    _df: DataFrame = (
+def spark_expectations_read_product_dataset(prepend: Optional[str] = None) -> DataFrame:
+    return (
         spark.read.option("header", "true")
         .option("inferSchema", "true")
-        .csv("file://" + os.path.join(os.path.dirname(__file__), "resources/customer.csv"))
+        .option("mode", "DROPMALFORMED")
+        .csv(prepend_csv_path(csv_filename="product.csv", prepend=prepend))
     )
-    return _df
+
+
+def spark_expectations_read_customer_dataset(prepend: Optional[str] = None) -> DataFrame:
+    return (
+        spark.read.option("header", "true")
+        .option("inferSchema", "true")
+        .option("mode", "DROPMALFORMED")
+        .csv(prepend_csv_path(csv_filename="customer.csv", prepend=prepend))
+    )
+
+
+def prepend_csv_path(csv_filename: str, prepend: Optional[str] = None) -> str:
+    """
+    Prepend a string to the given path if prepend is not None.
+    Args:
+        csv_filename (str): The CSV file name.
+        prepend (str): The string to prepend.
+    Returns:
+        str: The modified path.
+    Example:
+        >>> prepend_csv_path("employee.csv", "file:")
+        'file:/Users/developer/spark-expectations/spark_expectations/examples/resources/employee.csv'
+    """
+    path = pkg_resources.resource_filename("spark_expectations", f"examples/resources/{csv_filename}")
+    return path if prepend is None else f"{prepend}{path}"


### PR DESCRIPTION
Making loading of test data .csv file uniform

## Description
Read Example Dataset is leveraging Spark and Panda dataframe both for loading .csv files. 

Fix: 
- Modifying code to use uniform method. 
- Adding ability for users to specify protocol by prepending it to the .csv data path 
```
spark_expectations_read_product_dataset(prepend="file:")
```


## Related Issue
GH Issue : https://github.com/Nike-Inc/spark-expectations/issues/149

Some platforms when using spark.read.csv() will prepend file path with protocol ( example `dbfs:/`) to make file access seamless to users. In certain scenarios that will not work and will throw permission issue or unable to find the file itself.


## Motivation and Context
- same patterns (path resolution, libraries)
- addressing edge cases (DBX path prepending )

## How Has This Been Tested?
Testing changes by running samples in a notebook

## Screenshots (if appropriate):

Example showing DBX prepending `dbfs` to the Spark-Expectation filepath
```
# [PATH_NOT_FOUND] Path does not exist: dbfs:/local_disk0/.ephemeral_nfs/envs/pythonEnv-773cbd8e-24c8-4343-a008-cdebf200734f/lib/python3.12/site-packages/spark_expectations/examples/resources/product.csv. SQLSTATE: 42K03
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
