### PR TITLE
feature: adding local testing smtp server

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,6 +15,14 @@ check: black-check mypy
 mypy:
 	hatch run $(DEFAULT_HATCH_ENV):type-check
 
+local-mail-server-start:
+	@echo "Starting local mail server..."
+	sh ./spark_expectations/examples/docker_scripts/docker_mail_server_start_script.sh
+
+local-mail-server-stop:
+	@echo "Stopping local mail server..."
+	sh ./spark_expectations/examples/docker_scripts/docker_mail_server_stop_script.sh
+
 local-kafka-cluster-start:
 	@echo "Starting local Kafka cluster..."
 	. ./spark_expectations/examples/docker_scripts/docker_kafka_start_script.sh
@@ -73,7 +81,7 @@ test: kafka-cluster-start
 
 # make test-arg TEST=tests/sinks/utils/test_collect_statistics.py::test_collect_stats_on_success_failure 
 test-arg:
-	@hatch -e $(DEFAULT_HATCH_ENV) run pytest -ra -vv $(TEST)
+	@hatch -e $(DEFAULT_HATCH_ENV) run pytest -ra -vv -x $(TEST)
 
 build:
 	@hatch build

--- a/spark_expectations/examples/docker_scripts/docker-compose.yml
+++ b/spark_expectations/examples/docker_scripts/docker-compose.yml
@@ -1,0 +1,25 @@
+# docker-compose.yml
+version: '3.8'
+services:
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: se-mailpit
+    ports:
+      - "8025:8025"
+      - "1025:1025"
+    networks:
+      - se-net
+    volumes:
+      - ./certs/mailpit.crt:/certs/mailpit.crt:ro
+      - ./certs/mailpit.key:/certs/mailpit.key:ro
+    command:
+      [
+        "--smtp", "0.0.0.0:1025",
+        "--smtp-tls-cert", "/certs/mailpit.crt",
+        "--smtp-tls-key", "/certs/mailpit.key",
+        "--smtp-auth-accept-any"
+      ]         
+
+networks:
+  se-net:
+    external: true

--- a/spark_expectations/examples/docker_scripts/docker_kafka_start_script.sh
+++ b/spark_expectations/examples/docker_scripts/docker_kafka_start_script.sh
@@ -4,6 +4,15 @@ file_dir=$(dirname "$0")
 
 docker_container_name="spark_expectations_kafka_docker"
 docker_image_name="spark_expectations_kafka_topic"
+docker_network_name="se-net"
+
+# check if docker network exists, if not create it
+if [[ $(docker network ls | grep "$docker_network_name") ]]; then
+  echo "Docker network $docker_network_name already exists."
+else
+  echo "Creating Docker network $docker_network_name."
+  docker network create "$docker_network_name"
+fi
 
 if [[ $(docker ps -a | grep "$docker_container_name") ]]; then
   if [[ $(docker ps | grep "$docker_container_name") ]]; then
@@ -21,6 +30,6 @@ if [[ $(docker ps -a | grep "$docker_container_name") ]]; then
 else
 
    # rebuild the container with exuisting image
-  docker build -t $docker_image_name $file_dir && docker run --name $docker_container_name -d -h localhost -p 9092:9092 -i $docker_image_name
+  docker build -t $docker_image_name $file_dir && docker run --name $docker_container_name --network se-net -d -h localhost -p 9092:9092 -i $docker_image_name
 
 fi

--- a/spark_expectations/examples/docker_scripts/docker_mail_server_start_script.sh
+++ b/spark_expectations/examples/docker_scripts/docker_mail_server_start_script.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# shell scripts to create, start and run docker container, which contains mail server
+
+file_dir=$(dirname "$0")
+docker_container_name="se-mailpit"
+docker_network_name="se-net"
+
+# check if docker network exists, if not create it
+if [[ $(docker network ls | grep "$docker_network_name") ]]; then
+  echo "** Docker network '$docker_network_name' already exists."
+else
+  echo "** Creating Docker network $docker_network_name."
+  docker network create "$docker_network_name"
+fi
+
+# check if docker is running
+if ! docker info > /dev/null 2>&1; then
+  echo "** Docker is not running. Please start Docker and try again."
+  exit 1
+fi
+
+# Generate self-signed SSL certificate for mailpit
+if [[ ! -d "${file_dir}/certs" ]]; then
+  echo "** Creating 'certs' directory for SSL certificates."
+  mkdir "${file_dir}/certs"
+else
+  echo "** 'certs' directory already exists."
+  # Check if certs/mailpit.key and certs/mailpit.crt exist
+  if [[ ! -f "${file_dir}/certs/mailpit.key" || ! -f "${file_dir}/certs/mailpit.crt" ]]; then
+    echo "** Generating self-signed SSL certificate for mailpit."
+    openssl req -x509 -newkey rsa:4096 -keyout "${file_dir}/certs/mailpit.key" -out "${file_dir}/certs/mailpit.crt" -days 365 -nodes -subj "/CN=localhost"
+  else
+    echo "** SSL certificate files already exist."
+  fi
+fi
+
+# run docker compose to start the mail server
+docker_compose_file="$file_dir/docker-compose.yml"
+if [[ $(docker ps -a | grep "$docker_container_name") ]]; then
+    echo "** Container '$docker_container_name' is already running"
+else
+  echo "** Starting the docker container"
+  # rebuild the container with existing image
+  docker compose -f $docker_compose_file up -d --build
+fi

--- a/spark_expectations/examples/docker_scripts/docker_mail_server_stop_script.sh
+++ b/spark_expectations/examples/docker_scripts/docker_mail_server_stop_script.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#script to stop a mail server
+
+docker_container_name="se-mailpit"
+
+# check if docker is running
+if ! docker info > /dev/null 2>&1; then
+  echo "**Docker is not running. Please start Docker and try again."
+  exit 1
+fi
+# check if docker compose is installed 
+if ! command -v docker-compose &> /dev/null; then
+  echo "**Docker Compose is not installed. Please install Docker Compose and try again."
+  exit 1
+fi
+# check if the container is running
+if [[ $(docker ps | grep "$docker_container_name") ]]; then
+  echo "**Stopping the docker container"
+  docker stop "$docker_container_name"
+  docker rm "$docker_container_name"
+else
+  echo "**Container is not running"
+fi


### PR DESCRIPTION

## Description
- Adding local smtp server to test notifications 
- adding additional make targets to start/stop server

Adjusting existing Kafka container start arguments so that mail and kafka accessible to each other

```
make local-mail-server-start
make local-mail-server-stop

```

## Motivation and Context
Easier testing and development of available features (mail notifications)

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
