### PR TITLE
Defect/issue 43 some values are copied over

### DIFF
--- a/spark_expectations/core/expectations.py
+++ b/spark_expectations/core/expectations.py
@@ -365,6 +365,7 @@ class SparkExpectations:
                     self._context.set_source_query_dq_result()
                     self._context.set_final_query_dq_result()
                     self._context.set_summarized_row_dq_res()
+                    self._context.set_rules_exceeds_threshold()
                     self._context.set_dq_expectations(expectations)
 
                     # initialize variables of start and end time with default values

--- a/spark_expectations/core/expectations.py
+++ b/spark_expectations/core/expectations.py
@@ -351,6 +351,7 @@ class SparkExpectations:
                     _ignore_rules_result: List[Optional[List[Dict[str, str]]]] = []
 
                     # initialize variable with default values through set
+                    _log.info(f"initialize variable with default values before next run")
                     self._context.set_dq_run_status()
                     self._context.set_source_agg_dq_status()
                     self._context.set_source_query_dq_status()


### PR DESCRIPTION
This PR address the bug reported #43 
I added a missing call to reset context for "_rules_error_per" prior to each SE run

## Description
I tested the fix by running a notebook that fired the SE checks twice for two different table and made sure that the the row_dq_error_threshold column (stats table) is not getting copied over from the first run.

## Related Issue
(https://github.com/Nike-Inc/spark-expectations/issues/43)

## Motivation and Context
resolving a defect

## How Has This Been Tested?
I tested the fix by running a notebook that fired the SE checks twice for two different table and made sure that the the row_dq_error_threshold column (stats table) is not getting copied over from the first run.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
