### PR TITLE
Setting default value for dq_env as empty string

### DIFF
--- a/spark_expectations/sinks/utils/writer.py
+++ b/spark_expectations/sinks/utils/writer.py
@@ -719,9 +719,7 @@ class SparkExpectationsWriter:
             self._context.print_dataframe_with_debugger(df)
 
             # get env from user config
-            dq_env = (
-                None if "env" not in self._context.get_dq_rules_params else self._context.get_dq_rules_params["env"]
-            )
+            dq_env = "" if "env" not in self._context.get_dq_rules_params else self._context.get_dq_rules_params["env"]
 
             df = (
                 df.withColumn("output_percentage", sql_round(df.output_percentage, 2))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
very small PR to address issue with dq_env set as None.
This PR will replace None with empty string ""

## Related Issue
n/a

## Motivation and Context
n/a

## How Has This Been Tested?
I ran the test suit locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
