### PR TITLE
fix: missing library for users sqlglot

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -70,7 +70,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        architecture: [x86_64, arm64]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4 # use latest version of the checkout action

--- a/makefile
+++ b/makefile
@@ -62,10 +62,11 @@ env-remove-all:
 	@hatch env prune
 
 deploy_env_setup:
+	@hatch env create
 	@hatch env create dev
-	@hatch run dev:uv pip install --upgrade uv pip
-	@hatch run dev:uv pip install .[$(HATCH_FEATURES)]
-	@hatch run dev:uv pip freeze
+	@hatch run $(DEFAULT_HATCH_ENV):uv pip install --upgrade uv pip
+	@hatch run $(DEFAULT_HATCH_ENV):uv pip install .[$(HATCH_FEATURES)]
+	@hatch run $(DEFAULT_HATCH_ENV):uv pip freeze
 
 test: kafka-cluster-start
 	@hatch run $(DEFAULT_HATCH_ENV):coverage-ignore-failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requires-python = ">=3.9,<=3.13"
 dependencies = [
   "pluggy>=1",
   "requests>=2.28.1",
+  "sqlglot>=21.0,<23.0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -76,7 +77,6 @@ dependencies = [
   "types-setuptools==67.7.0.2",
   "pyyaml~=6.0.2",
   "types-PyYAML>=6.0.2",
-  "sqlglot>=21.0,<23.0",
 ]
 
 [tool.hatch.envs.dev.scripts]

--- a/spark_expectations/core/expectations.py
+++ b/spark_expectations/core/expectations.py
@@ -336,10 +336,8 @@ class SparkExpectations:
                     )
                     if failed:
                         # Optionally, raise or log details for each failed rule
-                        failed_rules = [r.get('rule') for rules_list in failed.values() for r in rules_list]
-                        raise SparkExpectationsMiscException(
-                            f"Validation failed for rules: {failed_rules}"
-                        )
+                        failed_rules = [r.get("rule") for rules_list in failed.values() for r in rules_list]
+                        raise SparkExpectationsMiscException(f"Validation failed for rules: {failed_rules}")
                     _log.info("Validation for rules completed successfully")
 
                     _input_count = _df.count()

--- a/spark_expectations/utils/actions.py
+++ b/spark_expectations/utils/actions.py
@@ -336,15 +336,14 @@ class SparkExpectationsActions:
                         )
 
                 if SparkExpectationsActions.match_parentheses(_dq_rule["expectation"]):
-
-                     # Improved: break down the regex pattern into logical sections for clarity
+                    # Improved: break down the regex pattern into logical sections for clarity
                     left_expr = r"\(.*\)"  # matches a parenthetical SQL expression
-                    operator = r"[<>!=]=?"   # matches comparison operators
+                    operator = r"[<>!=]=?"  # matches comparison operators
                     right_value = r"(\d+(?:\.\d+)?|\'[^\']*\')"  # matches int, float, or single-quoted string
                     right_expr = r"\(.*\)"  # matches a parenthetical SQL expression
                     # Combine into the full pattern
                     pattern = rf"({left_expr})\s*({operator})\s*({right_value}|({right_expr}))|({left_expr})"
-                    #pattern = r"(\(.*\))\s*([<>!=]=?)\s*((\d+(?:\.\d+)?|\'[^\']*\')|(\(.*\)))|(\(.*\))"
+                    # pattern = r"(\(.*\))\s*([<>!=]=?)\s*((\d+(?:\.\d+)?|\'[^\']*\')|(\(.*\)))|(\(.*\))"
 
                     match = re.search(pattern, _dq_rule["expectation"])
                     if match:

--- a/spark_expectations/utils/validate_rules.py
+++ b/spark_expectations/utils/validate_rules.py
@@ -9,17 +9,20 @@ from spark_expectations.core.exceptions import (
     SparkExpectationsInvalidAggDQExpectationException,
     SparkExpectationsInvalidQueryDQExpectationException,
     SparkExpectationsInvalidRowDQExpectationException,
-    SparkExpectationsInvalidRuleTypeException)
+    SparkExpectationsInvalidRuleTypeException,
+)
 
 import sqlglot
 from sqlglot.errors import ParseError
 
 from enum import Enum
 
+
 class RuleType(Enum):
     ROW_DQ = "row_dq"
     AGG_DQ = "agg_dq"
     QUERY_DQ = "query_dq"
+
 
 class SparkExpectationsValidateRules:
     """
@@ -56,7 +59,7 @@ class SparkExpectationsValidateRules:
         Args:
             df (DataFrame): The input DataFrame.
             rule (Dict): Rule containing the 'expectation' and 'rule'.
-            
+
         Raises:
             SparkExpectationsInvalidRowDQExpectationException: If aggregate functions are used or expression fails.
         """
@@ -83,7 +86,7 @@ class SparkExpectationsValidateRules:
                 f"[row_dq] Rule failed validation | rule_type: row_dq | "
                 f"rule: '{rule.get('rule')}' | expectation: '{expectation}' → {e}"
             )
-        
+
     @staticmethod
     def validate_agg_dq_expectation(df: DataFrame, rule: Dict) -> None:
         """
@@ -138,7 +141,7 @@ class SparkExpectationsValidateRules:
             raise SparkExpectationsInvalidQueryDQExpectationException(
                 f"[query_dq] Expectation does not appear to be a valid SQL SELECT query: '{query}'"
             )
-        
+
         # 2. Use extract_table_names_from_sql to find all table names/placeholders
         table_names = SparkExpectationsValidateRules.extract_table_names_from_sql(query)
         temp_view_name = "dummy_table"
@@ -146,10 +149,8 @@ class SparkExpectationsValidateRules:
 
         # 3. Replace each table name/placeholder with the dummy table name
         for table_name in table_names:
-            query_for_validation = re.sub(
-                rf"\b{re.escape(table_name)}\b", temp_view_name, query_for_validation
-            )
-        
+            query_for_validation = re.sub(rf"\b{re.escape(table_name)}\b", temp_view_name, query_for_validation)
+
         # 4. Handle {table} and similar placeholders
         query_for_validation = re.sub(r"\{[^\}]+\}", temp_view_name, query_for_validation)
 
@@ -157,10 +158,8 @@ class SparkExpectationsValidateRules:
         try:
             sqlglot.parse_one(query_for_validation)
         except ParseError as e:
-            raise SparkExpectationsInvalidQueryDQExpectationException(
-                f"[query_dq] Invalid SQL syntax (sqlglot): {e}"
-            )
-   
+            raise SparkExpectationsInvalidQueryDQExpectationException(f"[query_dq] Invalid SQL syntax (sqlglot): {e}")
+
     @staticmethod
     def validate_expectations(df: DataFrame, rules: list, spark: SparkSession) -> dict:
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sqlglot library is used to validate user provided rules. Fixing so that library is not part of dev dependecies so that it is automatically installed when users install spark-expectations rather then having to manually add it

Additional: 
- Code formatting
- Release github workflow, removing   `matrix.architecture` setting so it release is done on single, default cpu arch

## Screenshots (if appropriate):

<img width="734" height="48" alt="image" src="https://github.com/user-attachments/assets/f34d5256-9014-41b0-b2fc-cb04d6653b10" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
