### PR TITLE
fix: add missing kafka script

### DIFF
--- a/containers/kafka/scripts/start-kafka.sh
+++ b/containers/kafka/scripts/start-kafka.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Start Zookeeper
+$KAFKA_HOME/bin/zookeeper-server-start.sh -daemon $KAFKA_HOME/config/zookeeper.properties
+
+# Start Kafka
+$KAFKA_HOME/bin/kafka-server-start.sh -daemon $KAFKA_HOME/config/server.properties
+
+# Create a topic
+$KAFKA_HOME/bin/kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic dq-sparkexpectations-stats
+
+# Keep the container running
+tail -f /dev/null


### PR DESCRIPTION
- Local dev testing environment if failing to start one of the containers since it is missing kafka start script
- Adding certs folder

```bash

$> make local-se-server-start ARGS="--build"

...
...
...

 => ERROR [kafka 6/7] COPY containers/kafka/scripts/start-kafka.sh /usr/bin/                                                                     0.0s
------
 > [kafka 6/7] COPY containers/kafka/scripts/start-kafka.sh /usr/bin/:
------
failed to solve: failed to compute cache key: failed to calculate checksum of ref fce7ddb7-0e57-45c2-8cb0-87325ab8629b::p7nb7vp8ds73kkj2nu4q7xrmu: "/containers/kafka/scripts/start-kafka.sh": not found
```
