### PR TITLE
Fix: Coverage report not uploading to codecov

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -108,3 +108,4 @@ jobs:
           export PATH=$PATH:$HOME/.local/bin
           make build
           twine upload dist/*
+          

--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -108,4 +108,3 @@ jobs:
           export PATH=$PATH:$HOME/.local/bin
           make build
           twine upload dist/*
-          

--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -20,7 +20,9 @@ jobs:
       UNIT_TESTING_ENV: 'spark_expectations_unit_testing_on_github_actions'
 
     steps:
-      - uses: actions/checkout@v4 # use latest version of the checkout action
+      - uses: actions/checkout@v5 # use latest version of the checkout action
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -55,12 +57,13 @@ jobs:
           make cov
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
+        uses: codecov/codecov-action@v5
+        with:
           fail_ci_if_error: true
-
+          files: ./coverage.xml
+          verbose: true
+          slug: Nike-Inc/spark-expectations
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   deploy:
     name: Deploy to PyPi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was an issue with coverage reports not being uploaded to codecov. The last time it was uploaded for a merge to main was for commit a80943c which was over a year ago. Potentially, that is the reason codecov reports show 'X commits behind head on main'. This PR fixes the coverage upload issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
When this PR is merged to master, it should reset the Base to the latest commit on main. So all coverage reports will be compared to the latest commit on main that has coverage and should solve the issue described above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
