### PR TITLE
fix: backward compatibility - set default priority value for rules ta…

### DIFF
--- a/spark_expectations/utils/reader.py
+++ b/spark_expectations/utils/reader.py
@@ -328,7 +328,8 @@ class SparkExpectationsReader:
                         "description": row["description"],
                         "enable_error_drop_alert": row["enable_error_drop_alert"],
                         "error_drop_threshold": row["error_drop_threshold"],
-                        "priority": row["priority"],
+                        # TODO Rules table "priority" column should be required when we start leveraging it for notifications. For now, setting a default value.
+                        "priority": row["priority"] if "priority" in row else "medium",
                     }
 
                     if row["rule_type"] == self._context.get_query_dq_rule_type_name:


### PR DESCRIPTION
## Description
Setting for rules without "priority" column "medium" as a default value


## Motivation and Context
We are introducing Priority column but for the sake of backward compatibility for users that have Rules Table without this column we will set default value. 

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
