### PR TITLE
Adding wraps to preserve metadata for the function

### DIFF
--- a/spark_expectations/notifications/push/spark_expectations_notify.py
+++ b/spark_expectations/notifications/push/spark_expectations_notify.py
@@ -8,6 +8,7 @@ from spark_expectations import _log
 from spark_expectations.core.context import SparkExpectationsContext
 from spark_expectations.notifications import _notification_hook
 from spark_expectations.core.exceptions import SparkExpectationsMiscException
+from functools import wraps
 
 
 @dataclass
@@ -49,6 +50,7 @@ class SparkExpectationsNotify:
         """
 
         def decorator(func: Any) -> Any:
+            @wraps(func)
             def wrapper(*args: List, **kwargs: Dict) -> DataFrame:
                 if self._context.get_notification_on_start is True:
                     _on_start()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently the decorator does not wrap the function so the wrapped function will lose it's metadata including name and docstring. This PR fixes that issue

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
