### PR TITLE
Fix sql DQ rule for composite query & lint errors

### DIFF
--- a/spark_expectations/examples/read_example_dataset.py
+++ b/spark_expectations/examples/read_example_dataset.py
@@ -1,7 +1,9 @@
+from typing import Optional
+
 import pkg_resources
 from pyspark.sql import DataFrame
+
 from spark_expectations.core import get_spark_session
-from typing import Optional
 
 spark = get_spark_session()
 

--- a/spark_expectations/examples/sample_dq_delta.py
+++ b/spark_expectations/examples/sample_dq_delta.py
@@ -1,20 +1,20 @@
 # Define the product_id
+import os
 from typing import Dict, Union
 
-from pyspark.sql.types import StructType, StructField, IntegerType, StringType
-import os
-from spark_expectations.utils.reader import SparkExpectationsReader
-from spark_expectations.notifications.push.alert import SparkExpectationsAlert
-from spark_expectations.core.context import SparkExpectationsContext
-
 from pyspark.sql import DataFrame
+from pyspark.sql.types import StructType, StructField, IntegerType, StringType
+
 from spark_expectations import _log
-from spark_expectations.examples.base_setup import set_up_delta
+from spark_expectations.config.user_config import Constants as user_config
+from spark_expectations.core.context import SparkExpectationsContext
 from spark_expectations.core.expectations import (
     SparkExpectations,
     WrappedDataFrameWriter,
 )
-from spark_expectations.config.user_config import Constants as user_config
+from spark_expectations.examples.base_setup import set_up_delta
+from spark_expectations.notifications.push.alert import SparkExpectationsAlert
+from spark_expectations.utils.reader import SparkExpectationsReader
 
 
 writer = WrappedDataFrameWriter().mode("append").format("delta")

--- a/spark_expectations/notifications/push/spark_expectations_notify.py
+++ b/spark_expectations/notifications/push/spark_expectations_notify.py
@@ -1,14 +1,16 @@
-from dataclasses import dataclass
-from typing import Any, List, Dict
-import re
 import json
+import re
+from dataclasses import dataclass
 from datetime import date, datetime
+from functools import wraps
+from typing import Any, List, Dict
+
 from pyspark.sql import DataFrame
+
 from spark_expectations import _log
 from spark_expectations.core.context import SparkExpectationsContext
-from spark_expectations.notifications import _notification_hook
 from spark_expectations.core.exceptions import SparkExpectationsMiscException
-from functools import wraps
+from spark_expectations.notifications import _notification_hook
 
 
 @dataclass

--- a/spark_expectations/utils/validate_rules.py
+++ b/spark_expectations/utils/validate_rules.py
@@ -1,39 +1,32 @@
 import re
 from typing import Dict, List
 from enum import Enum
-
 import sqlglot
 from sqlglot.errors import ParseError
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import expr
-
 from spark_expectations.core.exceptions import (
     SparkExpectationsInvalidAggDQExpectationException,
     SparkExpectationsInvalidQueryDQExpectationException,
     SparkExpectationsInvalidRowDQExpectationException,
 )
 
-
 class RuleType(Enum):
     ROW_DQ = "row_dq"
     AGG_DQ = "agg_dq"
     QUERY_DQ = "query_dq"
 
-
 class SparkExpectationsValidateRules:
     """
     Performs validations for data quality rules like row_dq, agg_dq and query_dq.
     """
-
     @staticmethod
     def extract_table_names_from_sql(sql: str) -> List[str]:
         """
         Extracts table/view names from FROM and JOIN clauses
         in a SQL string using regex matching.
-
         Args:
             sql (str): SQL string.
-
         Returns:
             List[str]: Unique table/view names referenced in the query.
         """
@@ -43,7 +36,6 @@ class SparkExpectationsValidateRules:
             flags=re.IGNORECASE,
         )
         return list({name for pair in matches for name in pair if name})
-
     @staticmethod
     def validate_row_dq_expectation(df: DataFrame, rule: Dict) -> None:
         """
@@ -51,16 +43,13 @@ class SparkExpectationsValidateRules:
         1. It is a valid expression.
         2. The expectation runs successfully on a dataframe.
         3. It does NOT use aggregate functions.
-
         Args:
             df (DataFrame): The input DataFrame.
             rule (Dict): Rule containing the 'expectation' and 'rule'.
-
         Raises:
             SparkExpectationsInvalidRowDQExpectationException: If aggregate functions are used or expression fails.
         """
         expectation = rule.get("expectation", "")
-
         # Use sqlglot to detect aggregate functions
         try:
             tree = sqlglot.parse_one(expectation)
@@ -69,12 +58,10 @@ class SparkExpectationsValidateRules:
             raise SparkExpectationsInvalidRowDQExpectationException(
                 f"[row_dq] Could not parse expression: {expectation} → {e}"
             )
-
         if agg_funcs:
             raise SparkExpectationsInvalidRowDQExpectationException(
                 f"[row_dq] Rule '{rule.get('rule')}' contains aggregate function(s) (not allowed in row_dq): {agg_funcs}"
             )
-
         try:
             df.select(expr(expectation)).limit(1)
         except Exception as e:
@@ -82,21 +69,17 @@ class SparkExpectationsValidateRules:
                 f"[row_dq] Rule failed validation | rule_type: row_dq | "
                 f"rule: '{rule.get('rule')}' | expectation: '{expectation}' → {e}"
             )
-
     @staticmethod
     def validate_agg_dq_expectation(df: DataFrame, rule: Dict) -> None:
         """
         Validates an agg_dq expectation by ensuring it includes aggregate functions.
-
         Args:
             df (DataFrame): The input DataFrame.
             rule (Dict): Rule containing the 'expectation' and 'rule'.
-
         Raises:
             SparkExpectationsInvalidAggDQExpectationException: If no aggregate function is found or expression fails.
         """
         expectation = rule.get("expectation", "")
-
         # Use sqlglot to detect aggregate functions
         try:
             tree = sqlglot.parse_one(expectation)
@@ -105,12 +88,10 @@ class SparkExpectationsValidateRules:
             raise SparkExpectationsInvalidAggDQExpectationException(
                 f"[agg_dq] Could not parse expression: {expectation} → {e}"
             )
-
         if not agg_funcs:
             raise SparkExpectationsInvalidAggDQExpectationException(
                 f"[agg_dq] Rule '{rule.get('rule')}' does not contain a valid aggregate function: {expectation}"
             )
-
         try:
             df.selectExpr(expectation).limit(1)
         except Exception as e:
@@ -118,11 +99,9 @@ class SparkExpectationsValidateRules:
                 f"[agg_dq] Rule failed validation | rule_type: agg_dq | rule: '{rule.get('rule')}' | "
                 f"expectation: '{expectation}' → {e}"
             )
-
     @staticmethod
-    # pylint: disable=unused-argument
-    def validate_query_dq_expectation(df: DataFrame, rule: Dict, spark: SparkSession) -> None:
-        """
+    def validate_query_dq_expectation(_df: DataFrame, rule: Dict, _spark: SparkSession) -> None:
+        """ 
         Validates a query_dq expectation by ensuring it is a valid SQL query.
         Args:
             df (DataFrame): The input DataFrame.
@@ -130,43 +109,83 @@ class SparkExpectationsValidateRules:
             spark (SparkSession): Spark session.
         Raises:
             SparkExpectationsInvalidQueryDQExpectationException: If the query is not valid SQL or fails to parse.
+        
+        It validates 2 types of queries:
+            1. Simple quey like single "SELECT ... FROM ..."
+            2. Composite query with place holder(s) {} , delimiter(s) and subqueries like "SELECT ... FROM  {key1}...{key2}@key1@<subquery1@key2@<subquery2..."
+            
+            Example query: ((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b)) < 3@source_f1@select ...@target_f1@select ...
+            
+            First part of the composite query is called static until the first delimiter with place holders{}. ((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b)) < 3. 
+            Second part the compposite query is calleddynamic with delimiter(s)followed with subquerie(s).  @source_f1@select ...@target_f1@select ...
+            These subqueries will be placed in static query for the matching placeholder(s).
         """
-        query = rule.get("expectation", "")
-
-        # 1. Ensure it's a SELECT ... FROM ... query
-        if not re.search(r"\bselect\b.*\bfrom\b", query, re.IGNORECASE):
-            raise SparkExpectationsInvalidQueryDQExpectationException(
-                f"[query_dq] Expectation does not appear to be a valid SQL SELECT query: '{query}'"
-            )
-
-        # 2. Use extract_table_names_from_sql to find all table names/placeholders
+        raw = rule.get("expectation", "")
+        delimiter = rule.get("query_dq_delimiter") or "@"
+        # Split on delimiter to detect composite pattern
+        delimited_query_list = raw.split(delimiter)
+        dynamic_query_list = delimited_query_list[1:] if len(delimited_query_list) > 1 else []
+        # List should be even length as each key should have a corresponding subquery
+        is_composite_query = len(dynamic_query_list) >= 2 and len(dynamic_query_list) % 2 == 0
+        if is_composite_query:
+            # Split the dynamic sql into key-value pairs
+            dynamic_query_kv_pairs = {dynamic_query_list[i].strip(): dynamic_query_list[i + 1].strip() for i in range(0, len(dynamic_query_list), 2)}
+            # Validate each subquery and Ensure it's a SELECT ... FROM ... query
+            for key, subquery in dynamic_query_kv_pairs.items():
+                if not re.search(r"\bselect\b.*\bfrom\b", subquery, re.IGNORECASE):
+                    raise SparkExpectationsInvalidQueryDQExpectationException(
+                        f"[query_dq] Subquery '{subquery}' for key '{key}' is not a valid SELECT ... FROM:"
+                    )
+            # Insert subqueries into first part(static query) of the composite query for the matching placeholder(s). 
+            try:
+                static_query = delimited_query_list[0].strip().format(
+                    **{k: (v if v.lstrip().startswith("(") else f"({v})") for k, v in dynamic_query_kv_pairs.items()}
+                )
+            except KeyError as e:
+                raise SparkExpectationsInvalidQueryDQExpectationException(
+                    f"[query_dq] Missing key referenced in composite static query: {e}"
+                )
+            except Exception as e:
+                raise SparkExpectationsInvalidQueryDQExpectationException(
+                    f"[query_dq] Error formatting composite expectation: {e}"
+                )
+            # Replace any remaining {placeholders} (should not be any) to avoid parse errors
+            query = re.sub(r"\{[^}]+\}", "DUMMY_PLACEHOLDER", static_query) 
+        
+        else:
+            # --- Simple Query path with no place holders {} and delimiter(s) ---
+            query = raw
+            if not re.search(r"\bselect\b.*\bfrom\b", query, re.IGNORECASE):
+                raise SparkExpectationsInvalidQueryDQExpectationException(
+                    f"[query_dq] Expectation does not appear to be a valid SQL SELECT query: '{query}'"
+                )
+        
+        # Use extract_table_names_from_sql to find all table names/placeholders
         table_names = SparkExpectationsValidateRules.extract_table_names_from_sql(query)
         temp_view_name = "dummy_table"
         query_for_validation = query
-
-        # 3. Replace each table name/placeholder with the dummy table name
+        
+        #Replace each table name/placeholder with the dummy table name
         for table_name in table_names:
             query_for_validation = re.sub(rf"\b{re.escape(table_name)}\b", temp_view_name, query_for_validation)
-
-        # 4. Handle {table} and similar placeholders
-        query_for_validation = re.sub(r"\{[^\}]+\}", temp_view_name, query_for_validation)
-
-        # 5. Validate SQL syntax using sqlglot
+        
+        # Handle {table} and similar placeholders
+        query_for_validation = re.sub(r"\{[^}]+\}", temp_view_name, query_for_validation)
+        
+        #Validate SQL syntax using sqlglot
         try:
             sqlglot.parse_one(query_for_validation)
         except ParseError as e:
             raise SparkExpectationsInvalidQueryDQExpectationException(f"[query_dq] Invalid SQL syntax (sqlglot): {e}")
-
     @staticmethod
     def validate_expectations(df: DataFrame, rules: list, spark: SparkSession) -> dict:
         """
         Validates a list of rules and returns a map of failed rules by rule type.
-
         Args:
             df (DataFrame): Input DataFrame to validate against.
             rules (list): List of rule dictionaries.
             spark (SparkSession): Spark session.
-
+            
         Returns:
             dict: {RuleType: [failed_rule_dicts]}
         """

--- a/spark_expectations/utils/validate_rules.py
+++ b/spark_expectations/utils/validate_rules.py
@@ -111,14 +111,14 @@ class SparkExpectationsValidateRules:
             SparkExpectationsInvalidQueryDQExpectationException: If the query is not valid SQL or fails to parse.
         
         It validates 2 types of queries:
-            1. Simple quey like single "SELECT ... FROM ..."
-            2. Composite query with place holder(s) {} , delimiter(s) and subqueries like "SELECT ... FROM  {key1}...{key2}@key1@<subquery1@key2@<subquery2..."
+            1. Simple query like single "SELECT ... FROM ..."
+            2. Composite query with place holder(s) {}, delimiter(s), and subqueries like "SELECT ... FROM  {key1}...{key2}@key1@<subquery1@key2@<subquery2..."
             
             Example query: ((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b)) < 3@source_f1@select ...@target_f1@select ...
             
-            First part of the composite query is called static until the first delimiter with place holders{}. ((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b)) < 3. 
-            Second part the compposite query is calleddynamic with delimiter(s)followed with subquerie(s).  @source_f1@select ...@target_f1@select ...
-            These subqueries will be placed in static query for the matching placeholder(s).
+            First part of the composite query is called static until the first delimiter with place holders {}. ((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b)) < 3. 
+            Second part, the composite query, is called dynamic with delimiter(s) followed with subquerie(s):  @source_f1@select ...@target_f1@select ...
+            These subqueries will be placed in the static query for the matching placeholder(s).
         """
         raw = rule.get("expectation", "")
         delimiter = rule.get("query_dq_delimiter") or "@"

--- a/spark_expectations/utils/validate_rules.py
+++ b/spark_expectations/utils/validate_rules.py
@@ -172,7 +172,7 @@ class SparkExpectationsValidateRules:
         # Handle {table} and similar placeholders
         query_for_validation = re.sub(r"\{[^}]+\}", temp_view_name, query_for_validation)
         
-        #Validate SQL syntax using sqlglot
+        # Validate SQL syntax using sqlglot
         try:
             sqlglot.parse_one(query_for_validation)
         except ParseError as e:

--- a/spark_expectations/utils/validate_rules.py
+++ b/spark_expectations/utils/validate_rules.py
@@ -165,7 +165,7 @@ class SparkExpectationsValidateRules:
         temp_view_name = "dummy_table"
         query_for_validation = query
         
-        #Replace each table name/placeholder with the dummy table name
+        # Replace each table name/placeholder with the dummy table name
         for table_name in table_names:
             query_for_validation = re.sub(rf"\b{re.escape(table_name)}\b", temp_view_name, query_for_validation)
         

--- a/tests/integration/utils/test_validate_rules.py
+++ b/tests/integration/utils/test_validate_rules.py
@@ -135,8 +135,8 @@ def test_invalid_agg_dq(sample_df, expectation, spark):
         "SELECT SUM(col1) > 5 AS result",             # syntax error
         "col1 > 20",                                  # not a valid query_dq
         "avg(col1) < 100",                            # not a valid query_dq
-        "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f2}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@select distinct product_id,order_id from order_target",  # Place holder mismatch or missing
-        "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@@select distinct product_id,order_id from order_target",  # Place holder target_f1 missing
+        "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f2}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@select distinct product_id,order_id from order_target",  # Placeholder mismatch or missing
+        "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@@select distinct product_id,order_id from order_target",  # Placeholder target_f1 missing
         "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@invalid_query_without_select_from@target_f1@select distinct product_id,order_id from order_target",  # Invalid subquery without SELECT FROM
         "((select count(*) from ({}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@select distinct product_id,order_id from order_target",  # Missing key
         "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@{}",  # invalid_format Format in subquery

--- a/tests/integration/utils/test_validate_rules.py
+++ b/tests/integration/utils/test_validate_rules.py
@@ -139,7 +139,7 @@ def test_invalid_agg_dq(sample_df, expectation, spark):
         "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@@select distinct product_id,order_id from order_target",  # Placeholder target_f1 missing
         "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@invalid_query_without_select_from@target_f1@select distinct product_id,order_id from order_target",  # Invalid subquery without SELECT FROM
         "((select count(*) from ({}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@select distinct product_id,order_id from order_target",  # Missing key
-        "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@{}",  # invalid_format Format in subquery
+        "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@{}",  # Invalid format in subquery
         "((select count(*) from {source_f1=y} a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@select distinct product_id,order_id from order_target",  # Invalid format spec
         "select count(*) from table_name where col1 = = = invalid",  # Invalid SQL syntax
     ],

--- a/tests/integration/utils/test_validate_rules.py
+++ b/tests/integration/utils/test_validate_rules.py
@@ -78,6 +78,7 @@ def test_valid_agg_dq(sample_df, expectation, spark):
         "(select count(col1) from test_final_table_view) > 3",
         "(select count(case when col2>0 then 1 else 0 end) from test_final_table_view) > 10",
         "(select sum(col1) from {table}) > 10",
+        "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@select distinct product_id,order_id from order_target",
         "(select count(*) from test_table) > 10",
     ],
 )
@@ -97,6 +98,7 @@ def test_valid_query_dq(sample_df, expectation, spark):
         "sum(col1) > 20",  # agg_dq expression, not allowed in row_dq
         "(select stddev(col2) from test_table) > 0",  # SQL query, not allowed in row_dq
         "non_existing_col > 20",  # column does not exist
+        "col1 = = = invalid",  # Invalid syntax that sqlglot can't parse
     ],
 )
 def test_invalid_row_dq(sample_df, expectation, spark):
@@ -114,6 +116,7 @@ def test_invalid_row_dq(sample_df, expectation, spark):
     [
         "sum(non_existing_col) > 20",  # non_existing_col does not exist
         "col1 > 20",                   # not an aggregate expression
+        "sum(col1) = = = invalid",   # Invalid syntax that sqlglot can't parse
     ],
 )
 def test_invalid_agg_dq(sample_df, expectation, spark):
@@ -132,6 +135,13 @@ def test_invalid_agg_dq(sample_df, expectation, spark):
         "SELECT SUM(col1) > 5 AS result",             # syntax error
         "col1 > 20",                                  # not a valid query_dq
         "avg(col1) < 100",                            # not a valid query_dq
+        "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f2}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@select distinct product_id,order_id from order_target",  # Place holder mismatch or missing
+        "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@@select distinct product_id,order_id from order_target",  # Place holder target_f1 missing
+        "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@invalid_query_without_select_from@target_f1@select distinct product_id,order_id from order_target",  # Invalid subquery without SELECT FROM
+        "((select count(*) from ({}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@select distinct product_id,order_id from order_target",  # Missing key
+        "((select count(*) from ({source_f1}) a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@{}",  # invalid_format Format in subquery
+        "((select count(*) from {source_f1=y} a) - (select count(*) from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@select distinct product_id,order_id from order_target",  # Invalid format spec
+        "select count(*) from table_name where col1 = = = invalid",  # Invalid SQL syntax
     ],
 )
 def test_invalid_query_dq(sample_df, expectation, spark):


### PR DESCRIPTION
Fix query DQ validation rule to support composite queries with delimiters, placeholders and subqueries
Added test coverage
Fixed lint errors/warnings

## Description
Validation of Query DQ rules failing for composite query with delimiters. This PR will resolve this issue

## Related Issue
Below rules were failing earlier. This PR fixes the issue

((select count() from ({source_f1}) a) - (select count() from ({target_f1}) b) ) < 3@source_f1@select distinct product_id,order_id from order_source@target_f1@select distinct product_id,order_id from order_target

((select count() from ({source_f1}) a join ({source_f2}) b on a.customer_id = b.customer_id) - (select count() from ({target_f1}) a join ({target_f2}) b on a.customer_id = b.customer_id)) > ({target_f3})@source_f1@select customer_id, count() from customer_source group by customer_id@source_f2@select customer_id, count() from order_source group by customer_id@target_f1@select customer_id, count() from customer_target group by customer_id@target_f2@select customer_id, count() from order_target group by customer_id@target_f3@select count(*) from order_source
({source_f1}) > 10@source_f1@select count(*) from order_source

https://jira.nike.com/secure/RapidBoard.jspa?rapidView=18131&view=detail&selectedIssue=TLE-897#


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tested locally.
Ran couple of query DQ rules with composite queries. Also ran unit/integration tests at project level to cover the valid and invalid scenarios.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
