### PR TITLE
Pager Duty notification only on failure

### DIFF
--- a/docs/user_guide/notifications/pagerduty_notifications.md
+++ b/docs/user_guide/notifications/pagerduty_notifications.md
@@ -9,17 +9,36 @@ By default PagerDuty notifications (or the ability to create incidents) are disa
 !!! info "user_config.se_notifications_enable_pagerduty"
     Master toggle to enable PagerDuty notifications (this will create incidents for your service!)
 
+!!! warning "PagerDuty Failure-Only Behavior"
+    **PagerDuty incidents are only created for critical failure scenarios**, regardless of which notification triggers are enabled. This ensures PagerDuty is used appropriately for alerting on issues that require immediate attention, rather than routine status updates or informational notifications.
+    
+    PagerDuty incidents will be triggered for:
+    
+    - **Job failures** (`se_notifications_on_fail`)
+    - **Error threshold breaches** (`se_notifications_on_error_drop_exceeds_threshold_breach`) 
+    
+    PagerDuty incidents will **NOT** be triggered for:
+    
+    - Job start notifications (`se_notifications_on_start`)
+    - Job completion notifications (`se_notifications_on_completion`)
+    - **Rules with 'ignore' action that fail** (`se_notifications_on_rules_action_if_failed_set_ignore`) - These are informational only
+    
+    !!! note "Rules with 'ignore' action"
+        When `se_notifications_on_rules_action_if_failed_set_ignore` is enabled, notifications will be sent to other channels (email, Slack, Teams, etc.) for informational purposes, but **PagerDuty incidents will NOT be created**. Rules marked with `action_if_failed='ignore'` are not considered critical failures requiring immediate incident response.
+    
+    Other notification channels (email, Slack, Teams, etc.) will continue to respect all configured triggers.
+
 
 ??? info "Notification triggers"
-    These parameters control **when** notifications are sent during Spark-Expectations runs. This would create a new incident per enabled trigger.  
+    These parameters control **when** notifications are sent during Spark-Expectations runs. **Note: PagerDuty will only create incidents for failure-related triggers**, regardless of which triggers are enabled.
     `Hover over each parameter to see a short description.`
        
     - <abbr title="Master toggle to enable PagerDuty notifications">user_config.se_notifications_enable_pagerduty</abbr>
-    - <abbr title="Enable notifications when job starts">user_config.se_notifications_on_start</abbr>
-    - <abbr title="Enable notifications when job ends">user_config.se_notifications_on_completion</abbr>
-    - <abbr title="Enable notifications on failure">user_config.se_notifications_on_fail</abbr>
-    - <abbr title="Notify if error drop threshold is breached">user_config.se_notifications_on_error_drop_exceeds_threshold_breach</abbr>
-    - <abbr title="Notify if rules with action 'ignore' fail">user_config.se_notifications_on_rules_action_if_failed_set_ignore</abbr>
+    - <abbr title="Enable notifications when job starts (PagerDuty will ignore this)">user_config.se_notifications_on_start</abbr>
+    - <abbr title="Enable notifications when job ends (PagerDuty will ignore this)">user_config.se_notifications_on_completion</abbr>
+    - <abbr title="Enable notifications on failure (PagerDuty will create incident)">user_config.se_notifications_on_fail</abbr>
+    - <abbr title="Notify if error drop threshold is breached (PagerDuty will create incident)">user_config.se_notifications_on_error_drop_exceeds_threshold_breach</abbr>
+    - <abbr title="Notify if rules with action 'ignore' fail (PagerDuty will NOT create incident - informational only)">user_config.se_notifications_on_rules_action_if_failed_set_ignore</abbr>
     - <abbr title="Threshold value for error drop notifications">user_config.se_notifications_on_error_drop_threshold</abbr>
 
 

--- a/tests/unit/notification/plugins/test_pagerduty.py
+++ b/tests/unit/notification/plugins/test_pagerduty.py
@@ -5,14 +5,16 @@ from spark_expectations.core.exceptions import SparkExpectationsPagerDutyExcepti
 from spark_expectations.notifications.plugins.pagerduty import SparkExpectationsPagerDutyPluginImpl
 
 
-@patch("spark_expectations.notifications.plugins.pagerduty.SparkExpectationsContext", autospec=True, spec_set=True)
+@patch("spark_expectations.notifications.plugins.pagerduty.SparkExpectationsContext", autospec=True)
 def test_send_incident_success(_mock_context):
     pagerduty_handler = SparkExpectationsPagerDutyPluginImpl()
     _mock_context.get_enable_pagerduty = True
     _mock_context.get_pagerduty_webhook_url = "https://events.pagerduty.com/v2/change/enqueue"
     _mock_context.get_pagerduty_integration_key = "test_integration_key"
+    _mock_context.product_id = "test_product"
+    _mock_context.get_table_name = "test_table"
 
-    _config_args = {"message": "test message"}
+    _config_args = {"message": "Spark expectations job has been failed"}
 
     # Mock requests.post to return a response with status code 200
     with patch.object(requests, "post") as mock_post:
@@ -28,9 +30,10 @@ def test_send_incident_success(_mock_context):
             _mock_context.get_pagerduty_webhook_url,
             json={
                 "routing_key": _mock_context.get_pagerduty_integration_key,
+                "dedup_key": "spark_expectations_test_product_test_table_failure",
                 "event_action": "trigger",
                 "payload": {
-                    "summary": "test message",
+                    "summary": "Spark expectations job has been failed",
                     "source": "Spark Expectations",
                     "severity": "error",
                 },
@@ -45,7 +48,7 @@ def test_send_incident_exception(_mock_context):
     pagerduty_handler = SparkExpectationsPagerDutyPluginImpl()
     _mock_context.get_enable_pagerduty = True
     _mock_context.get_pagerduty_webhook_url = "http://test_webhook_url"
-    _config_args = {"message": "test message"}
+    _config_args = {"message": "Spark expectations job has been failed"}
 
     with patch.object(requests, "post") as mock_post:
         mock_response = Mock()
@@ -257,3 +260,136 @@ def test_send_incident_pagerduty_disabled(_mock_context):
     with patch.object(requests, "post") as mock_post:
         pagerduty_handler.send_notification(_context=_mock_context, _config_args=_config_args)
         mock_post.post.assert_not_called()
+
+
+@patch("spark_expectations.notifications.plugins.pagerduty.SparkExpectationsContext", autospec=True, spec_set=True)
+def test_send_incident_skipped_for_non_failure_message(_mock_context):
+    """Test that PagerDuty notifications are skipped for non-failure messages like job start/completion"""
+    pagerduty_handler = SparkExpectationsPagerDutyPluginImpl()
+    _mock_context.get_enable_pagerduty = True
+    _mock_context.get_pagerduty_webhook_url = "https://events.pagerduty.com/v2/enqueue"
+    _mock_context.get_pagerduty_integration_key = "test_integration_key"
+
+    # Test with job start message
+    _config_args = {"message": "Spark expectations job has started \n\ntable_name: test_table\nrun_id: 123"}
+
+    with patch.object(requests, "post") as mock_post:
+        pagerduty_handler.send_notification(_context=_mock_context, _config_args=_config_args)
+        # Should not call post since this is not a failure
+        mock_post.assert_not_called()
+
+
+@patch("spark_expectations.notifications.plugins.pagerduty.SparkExpectationsContext", autospec=True, spec_set=True)
+def test_send_incident_skipped_for_completion_message(_mock_context):
+    """Test that PagerDuty notifications are skipped for job completion messages"""
+    pagerduty_handler = SparkExpectationsPagerDutyPluginImpl()
+    _mock_context.get_enable_pagerduty = True
+    _mock_context.get_pagerduty_webhook_url = "https://events.pagerduty.com/v2/enqueue"
+    _mock_context.get_pagerduty_integration_key = "test_integration_key"
+
+    # Test with job completion message
+    _config_args = {"message": "Spark expectations job has been completed \n\nproduct_id: test_product"}
+
+    with patch.object(requests, "post") as mock_post:
+        pagerduty_handler.send_notification(_context=_mock_context, _config_args=_config_args)
+        # Should not call post since this is not a failure
+        mock_post.assert_not_called()
+
+
+@patch("spark_expectations.notifications.plugins.pagerduty.SparkExpectationsContext", autospec=True)
+def test_send_incident_for_job_failure_message(_mock_context):
+    """Test that PagerDuty notifications are sent for job failure messages"""
+    pagerduty_handler = SparkExpectationsPagerDutyPluginImpl()
+    _mock_context.get_enable_pagerduty = True
+    _mock_context.get_pagerduty_webhook_url = "https://events.pagerduty.com/v2/enqueue"
+    _mock_context.get_pagerduty_integration_key = "test_integration_key"
+    _mock_context.product_id = "test_product"
+    _mock_context.get_table_name = "test_table"
+
+    # Test with job failure message
+    _config_args = {"message": "Spark expectations job has been failed \n\nproduct_id: test_product"}
+
+    with patch.object(requests, "post") as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 202
+        mock_post.return_value = mock_response
+
+        pagerduty_handler.send_notification(_context=_mock_context, _config_args=_config_args)
+        # Should call post since this is a failure
+        mock_post.assert_called_once()
+
+
+@patch("spark_expectations.notifications.plugins.pagerduty.SparkExpectationsContext", autospec=True)
+def test_send_incident_for_error_threshold_breach(_mock_context):
+    """Test that PagerDuty notifications are sent for error threshold breach messages"""
+    pagerduty_handler = SparkExpectationsPagerDutyPluginImpl()
+    _mock_context.get_enable_pagerduty = True
+    _mock_context.get_pagerduty_webhook_url = "https://events.pagerduty.com/v2/enqueue"
+    _mock_context.get_pagerduty_integration_key = "test_integration_key"
+    _mock_context.product_id = "test_product"
+    _mock_context.get_table_name = "test_table"
+
+    # Test with error threshold breach message
+    _config_args = {"message": "Spark expectations - dropped error percentage has been exceeded above the threshold value(5%) for `row_data` quality validation"}
+
+    with patch.object(requests, "post") as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 202
+        mock_post.return_value = mock_response
+
+        pagerduty_handler.send_notification(_context=_mock_context, _config_args=_config_args)
+        # Should call post since this is an error condition
+        mock_post.assert_called_once()
+
+
+@patch("spark_expectations.notifications.plugins.pagerduty.SparkExpectationsContext", autospec=True, spec_set=True)
+def test_send_incident_skipped_for_ignored_rules_failure(_mock_context):
+    """Test that PagerDuty notifications are NOT sent for ignored rules failure messages.
+    
+    These are informational notifications only and should not create PagerDuty incidents.
+    PagerDuty incidents should only be created for actual critical failures.
+    """
+    pagerduty_handler = SparkExpectationsPagerDutyPluginImpl()
+    _mock_context.get_enable_pagerduty = True
+    _mock_context.get_pagerduty_webhook_url = "https://events.pagerduty.com/v2/enqueue"
+    _mock_context.get_pagerduty_integration_key = "test_integration_key"
+
+    # Test with ignored rules failure message
+    _config_args = {"message": "Spark expectations notification on rules which action_if_failed are set to ignore"}
+
+    with patch.object(requests, "post") as mock_post:
+        pagerduty_handler.send_notification(_context=_mock_context, _config_args=_config_args)
+        # Should NOT call post since this is just an informational notification about ignored rules
+        mock_post.assert_not_called()
+
+
+def test_is_failure_notification():
+    """Test the _is_failure_notification method with various message types"""
+    pagerduty_handler = SparkExpectationsPagerDutyPluginImpl()
+    
+    # Test failure messages that should return True
+    failure_messages = [
+        "Spark expectations job has been failed",
+        "Job FAILED due to error",
+        "Spark expectations - dropped error percentage has been exceeded above the threshold",
+        "Something went wrong and FAILED",
+    ]
+    
+    for message in failure_messages:
+        assert pagerduty_handler._is_failure_notification(message) is True, f"Should detect failure in: {message}"
+    
+    # Test non-failure messages that should return False
+    # NOTE: Ignored rules notifications are informational only and should NOT create PagerDuty incidents
+    non_failure_messages = [
+        "Spark expectations job has started",
+        "Spark expectations job has been completed",
+        "Spark expectations notification on rules which action_if_failed are set to ignore",  # Informational only
+        "Everything is working fine",
+        "Job succeeded",
+        "Processing data successfully",
+        "",
+        None,
+    ]
+    
+    for message in non_failure_messages:
+        assert pagerduty_handler._is_failure_notification(message) is False, f"Should not detect failure in: {message}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added Pager duty to trigger only on failure(either job failure or rule failure)

## Related Issue
Pager duty alert should be sent only incase of critical failures Even if notifications are enabled (notify on start, on completion, etc.), PagerDuty incidents are only sent on job failure and also on rule failure

## Motivation and Context
To stop unwanted alerts and only alert on critical failures that need immediate attention

## How Has This Been Tested?
Tested it locally and was able to trigger pager duty only on failures

## Screenshots (if appropriate):
<img width="1370" height="713" alt="image" src="https://github.com/user-attachments/assets/479c7c61-9975-468c-aa23-4574cc9a8e6b" />
<img width="766" height="319" alt="image" src="https://github.com/user-attachments/assets/af35ce78-880f-4d1f-b4a3-0d88279a067d" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
