### PR TITLE
Fix docs deployment and add missing navigation links

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -112,6 +112,9 @@ jobs:
           make build
           twine upload dist/*
       - name: Publish Docs
-        run: make deploy-docs
+        run: |
+          export PATH=$PATH:$HOME/.local/bin
+          VERSION=$(hatch version)
+          make deploy-docs version=$VERSION
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/email_notifications.md
+++ b/docs/email_notifications.md
@@ -4,7 +4,7 @@ Spark Expectations can send three kinds of emails.
 
 ## 1. Data Quality Report Emails
 
-Please see the [Observability Examples doc](Observability_examples) for more detailed information on emails that contain the DQ report.
+Please see the [Observability Examples doc](Observability_examples.md) for more detailed information on emails that contain the DQ report.
 
 
 ## 2. Basic Email Notifications/Alerts

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,7 +87,9 @@ nav:
           - Base_Notification_plugin: api/base_notification_plugin.md
           - Email_Notification_plugin: api/email_plugin.md
           - Slack_Notification_plugin: api/slack_plugin.md
+          - Teams_Notification_plugin: api/teams_plugin.md
           - PagerDuty_Notification_plugin: api/pagerduty_plugin.md
+          - Zoom_Notification_plugin: api/zoom_plugin.md
           - Push:
               - Notification_Decorater: api/notifications_decorater.md
       - Utils:
@@ -97,6 +99,9 @@ nav:
           - Udf: api/udf.md
       - Examples:
           - Base_Setup: api/base_setup.md
+          - Sample_DQ_BigQuery: api/sample_dq_bigquery.md
+          - Sample_DQ_Delta: api/sample_dq_delta.md
+          - Sample_DQ_Iceberg: api/sample_dq_iceberg.md
 
 plugins:
   - search:
@@ -104,7 +109,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          paths: [ "spark_expectations" ]
+          paths: [ "." ]
           options:
             show_source: true
             show_root_heading: false


### PR DESCRIPTION
- Add version extraction for docs deployment in GitHub Actions
- Include examples module in mkdocs paths
- Add missing API docs to navigation (teams, zoom, sample_dq_*)

<!--- Provide a general summary of your changes in the Title above -->

## Description
1. GitHub Actions Deployment Fix: Added version extraction using hatch version in the onpush.yml workflow to properly pass version information when deploying docs with mike deploy
2. Module Path Fix: Updated mkdocs.yml paths configuration from ["spark_expectations"] to ["."] to include the examples module, resolving ModuleNotFoundError for examples.scripts modules
3. Missing Navigation Links: Added 5 missing API documentation files to the mkdocs.yml navigation:
  Teams_Notification_plugin
  Zoom_Notification_plugin
  Sample_DQ_BigQuery
  Sample_DQ_Delta
  Sample_DQ_Iceberg
4. Broken Link Fix: Fixed broken link in email_notifications.md by adding missing .md extension


## Related Issue
Fixes documentation deployment failures in GitHub Actions with error:

## Motivation and Context
The mkdocs build was failing with ModuleNotFoundError: No module named 'examples' because mkdocstrings couldn't find the examples package.


## How Has This Been Tested?
Verified local repository file structure matches the changes
Confirmed all referenced files exist in the repository
Validated mkdocs.yml navigation structure
Checked GitHub Actions workflow syntax
Verified that hatch version command works with the project's vcs-based versioning

## Screenshots (if appropriate):
N/A - Configuration and workflow fixes


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ X] My change requires a change to the documentation.
- [ X] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
