### PR TITLE
Add logic to check for user-defined error table name from _context an…

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -63,7 +63,7 @@ se_user_conf = {
 17. When `user_config.se_notifications_on_error_drop_exceeds_threshold_breach` parameter set to `True` enables notification when error threshold reaches above the configured value 
 18. When `user_config.se_notifications_on_rules_action_if_failed_set_ignore` parameter set to `True` enables notification when rules action is set to ignore if failed 
 19. The `user_config.se_notifications_on_error_drop_threshold` parameter captures error drop threshold value 
-20. The `user_config.se_enable_error_table` parameter, which controls whether error data to load into error table, is set to true by default 
+20. The `user_config.se_enable_error_table` parameter, which controls whether error data to load into error table, is set to true by default. The default error table name is `<target_table>_error`; users can override it by calling `set_error_table_name(...)` on the `SparkExpectations` instance context (for example, `se._context.set_error_table_name("catalog.schema.custom_error_table")`) before executing the decorated function.
 21. When `user_config.enable_query_dq_detailed_result` parameter set to `True`, enables the option to capture the query_dq detailed stats to detailed_stats table. By default set to `False`
 22. When `user_config.enable_agg_dq_detailed_result` parameter set to `True`, enables the option to capture the agg_dq detailed stats to detailed_stats table. By default set to `False`
 23. The `user_config.querydq_output_custom_table_name` parameter is used to specify the name of the custom query_dq output table which captures the output of the alias queries passed in the query dq expectation. Default is <stats_table>_custom_output 

--- a/docs/home/why_spark_expectations.md
+++ b/docs/home/why_spark_expectations.md
@@ -22,9 +22,10 @@ on both the source and validated data sets. In case a rules fails, the row-level
 and a summarized report of all failed aggregated data quality rules is compiled in the `_stats` table. 
 * Spark Expectations optionally provides detailed, rule-level records showing the execution and results of each rule. 
 These per-rule validation results are captured in the `stats_detailed` table, allowing for thorough inspection and analysis.
-* All the records which fail one or more data quality rules, are by default quarantined in an `_error` table along with 
+* All the records which fail one or more data quality rules, are by default quarantined in an `_error` table (default name: `<target_table>_error`) along with 
 the metadata on rules that failed, job information etc. This helps analysts or products to look at the error data easily 
 and work with the teams required to correct the data and reprocess it easily
+  * If you need a custom error table name/location, override it on your `SparkExpectations` instance context before executing the decorated function (for example, `se._context.set_error_table_name("catalog.schema.custom_error_table")`).
 * Aggregated Metrics are provided on the job level along with necessary metadata so that recalculation or compute is 
 avoided
 * The data that doesn't meet the data quality contract or the standards is not written into the final table unless or

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -193,6 +193,9 @@ se = SparkExpectations(
     stats_streaming_options=stats_streaming_config_dict   # (6)!
 )
 
+# Optional: override the default error table name (default: `<target_table>_error`)
+se._context.set_error_table_name(f"{catalog}.{schema}.{target_table_name}_dq_error")
+
 """
 This decorator helps to wrap a function which returns dataframe and apply dataframe rules on it
 

--- a/spark_expectations/core/context.py
+++ b/spark_expectations/core/context.py
@@ -38,6 +38,7 @@ class SparkExpectationsContext:
         self._dq_detailed_stats_table_name: Optional[str] = None
         self._final_table_name: Optional[str] = None
         self._error_table_name: Optional[str] = None
+        self._error_table_name_user_specified: bool = False
         self._row_dq_rule_type_name: str = "row_dq"
         self._agg_dq_rule_type_name: str = "agg_dq"
         self._query_dq_rule_type_name: str = "query_dq"
@@ -335,16 +336,17 @@ class SparkExpectationsContext:
             accessing it"""
         )
 
-    def set_error_table_name(self, error_table_name: str) -> None:
+    def set_error_table_name(self, error_table_name: str, user_specified: bool = True) -> None:
         self._error_table_name = error_table_name
+        self._error_table_name_user_specified = user_specified
 
     @property
     def get_error_table_name(self) -> str:
         """
-        Get dq_stats_table_name to which the final stats of the dq job will be written into
+        Get error_table_name to which the final stats of the dq job will be written into
 
         Returns:
-            str: returns the dq_stats_table_name
+            str: returns error_table_name attribute value
         """
         if self._error_table_name:
             return self._error_table_name
@@ -352,6 +354,13 @@ class SparkExpectationsContext:
             """The spark expectations context is not set completely, please assign '_error_table_name' before 
             accessing it"""
         )
+
+    @property
+    def get_error_table_name_user_specified(self) -> bool:
+        """
+        Returns True if user override default error table name, otherwise False
+        """
+        return self._error_table_name_user_specified
 
     def set_min_priority_email(self, min_priority_email: str) -> None:
         self._min_priority_email = min_priority_email

--- a/spark_expectations/core/expectations.py
+++ b/spark_expectations/core/expectations.py
@@ -434,7 +434,6 @@ class SparkExpectations:
                             _writer=self._writer,
                             _notification=self._notification,
                             expectations=expectations,
-                            table_name=table_name,
                             _input_count=_input_count,
                         )
 

--- a/spark_expectations/utils/reader.py
+++ b/spark_expectations/utils/reader.py
@@ -279,7 +279,6 @@ class SparkExpectationsReader:
         """
         try:
             self._context.set_final_table_name(target_table)
-            self._context.set_error_table_name(f"{target_table}_error")
             self._context.set_table_name(target_table)
             self._context.set_env(os.environ.get("SPARKEXPECTATIONS_ENV"))
 
@@ -287,6 +286,9 @@ class SparkExpectationsReader:
             self._context.reset_num_dq_rules()
             self._context.reset_num_row_dq_rules()
             self._context.reset_num_query_dq_rules()
+            
+            if not self._context.get_error_table_name_user_specified:
+                self._context.set_error_table_name(f"{target_table}_error", user_specified=False)
 
             if params is not None:
                 rules_df = reduce(

--- a/spark_expectations/utils/regulate_flow.py
+++ b/spark_expectations/utils/regulate_flow.py
@@ -28,7 +28,6 @@ class SparkExpectationsRegulateFlow:
         _writer: SparkExpectationsWriter,
         _notification: SparkExpectationsNotify,
         expectations: Dict[str, List[dict]],
-        table_name: str,
         _input_count: int = 0,
     ) -> Any:
         """
@@ -39,7 +38,6 @@ class SparkExpectationsRegulateFlow:
             _writer: SparkExpectationsWriter class object
             _notification: SparkExpectationsNotify class object
             expectations: expectations dictionary which contains rules
-            table_name: name of the table
             _input_count: number of records in the source dataframe
         Returns:
                Any: returns function
@@ -114,7 +112,7 @@ class SparkExpectationsRegulateFlow:
 
                     _error_count, _error_df = _writer.write_error_records_final(
                         _df_dq,
-                        f"{table_name}_error",
+                        _context.get_error_table_name,
                         _context.get_row_dq_rule_type_name,
                     )
                     if _context.get_summarized_row_dq_res:

--- a/tests/integration/utils/test_regulate_flow.py
+++ b/tests/integration/utils/test_regulate_flow.py
@@ -1945,11 +1945,13 @@ def test_execute_dq_process(
     spark.conf.set("spark.sql.session.timeZone", "Etc/UTC")
     df.createOrReplaceTempView("test_table")
     _fixture_context._dq_expectations = expectations
+    _fixture_context.set_table_name("dq_spark.test_final_table")
+    _fixture_context.set_error_table_name("dq_spark.test_final_table_error", user_specified=False)
     writer = SparkExpectationsWriter(_fixture_context)
     regulate_flow = SparkExpectationsRegulateFlow("product1")
 
     func_process = regulate_flow.execute_dq_process(
-        _fixture_context, _fixture_actions, writer, _mock_notify, expectations, "dq_spark.test_final_table", input_count
+        _fixture_context, _fixture_actions, writer, _mock_notify, expectations, input_count
     )
 
     # assert if expected output raises certain exception for failure
@@ -2178,7 +2180,7 @@ def test_execute_dq_process_exception(
         writer = SparkExpectationsWriter(mock_contextt)
         regulate_flow = SparkExpectationsRegulateFlow("product1")
         func_process = regulate_flow.execute_dq_process(
-            mock_contextt, actions, writer, expectations, "dq_spark.test_final_table", input_count
+            mock_contextt, actions, writer, Mock(), expectations, input_count
         )
 
         (_df, _agg_dq_res, _error_count, _status) = func_process(

--- a/tests/unit/utils/test_actions.py
+++ b/tests/unit/utils/test_actions.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, MagicMock
 from unittest.mock import patch
 
 import pytest
@@ -7,6 +7,8 @@ from pyspark.sql.functions import lit, struct, array, udf
 from spark_expectations.core.context import SparkExpectationsContext
 from spark_expectations.core.exceptions import SparkExpectationsMiscException
 from spark_expectations.utils.actions import SparkExpectationsActions
+from spark_expectations.utils.reader import SparkExpectationsReader
+from spark_expectations.utils.regulate_flow import SparkExpectationsRegulateFlow
 
 
 @pytest.fixture(name="_fixture_agg_dq_rule")
@@ -80,3 +82,83 @@ def test_agg_query_dq_detailed_result_exception():
         SparkExpectationsActions().agg_query_dq_detailed_result(
             _mock_object_context, "_fixture_query_dq_rule", "<df>", []
         )
+
+
+def _mock_rules_df_empty():
+    """Used by test_default_error_table_naming to allow get_rules_from_df to run without real Spark DataFrame ops."""
+    rules_df = MagicMock()
+    filtered_df = MagicMock()
+    rules_df.filter.return_value = filtered_df
+    filtered_df.collect.return_value = []
+    return rules_df
+
+
+def test_default_error_table_naming():
+    """Expectation: The default behavior of appending _error to the table name still works"""
+    ctx = SparkExpectationsContext(product_id="p1", spark=Mock())
+
+    reader = SparkExpectationsReader(_context=ctx)
+
+    reader._get_rules_execution_settings = Mock(return_value={}) # avoid spark transformations inside _get_rules_execution_settings
+
+    reader.get_rules_from_df(rules_df=_mock_rules_df_empty(), target_table="my_db.target_table") # call get_rules_from_df which calls sets self._context.set_error_table_name(f"{target_table}_error")
+
+    assert ctx.get_error_table_name == "my_db.target_table_error" # validate the default error table name for 'target_table'
+    assert ctx.get_error_table_name_user_specified is False
+
+
+def test_error_table_override():
+    """ Expectation: different_catalog.my_override_error is used as the error table instead of the default my_db.target_table_error"""
+    target_table_override= "different_catalog.my_override_error" # Define the error table name we want
+    ctx = SparkExpectationsContext(product_id="p1", spark=Mock())
+    ctx.set_error_table_name(target_table_override) #  set_error_table_name as different_catalog.my_override_error
+
+    actions = Mock()
+    writer = Mock()
+    notification = Mock()
+
+    dq_df = MagicMock(name="dq_df")
+    error_df = MagicMock(name="error_df")
+
+    actions.run_dq_rules.return_value = dq_df
+    actions.action_on_rules.return_value = MagicMock(name="out_df")
+    writer.write_error_records_final.return_value = (0, error_df)
+
+    process = SparkExpectationsRegulateFlow.execute_dq_process(
+        _context=ctx,
+        _actions=actions,
+        _writer=writer,
+        _notification=notification,
+        expectations={},
+        _input_count=1,
+    )
+
+    process(df=MagicMock(name="input_df"), _rule_type="row_dq", row_dq_flag=True)
+
+    # Assert that write_error_records_final was called with target_table_override instead of "my_db.target_table_error"
+    writer.write_error_records_final.assert_called_once_with(
+        dq_df,
+        target_table_override,
+        ctx.get_row_dq_rule_type_name,
+    )
+
+    # Assert that the get_error_table method returns the override value
+    assert ctx.get_error_table_name == target_table_override
+    assert ctx.get_error_table_name_user_specified is True
+
+
+def test_multi_decorator_default_updates():
+    """Verify default error table updates across multiple decorator calls"""
+    ctx = SparkExpectationsContext(product_id="p1", spark=Mock())
+    reader = SparkExpectationsReader(_context=ctx)
+    reader._get_rules_execution_settings = Mock(return_value={})
+
+    # First call
+    reader.get_rules_from_df(rules_df=_mock_rules_df_empty(), target_table="db.table_a")
+    assert ctx.get_error_table_name == "db.table_a_error"
+    assert ctx.get_error_table_name_user_specified is False
+
+    # Second call - should update, not stick
+    reader.get_rules_from_df(rules_df=_mock_rules_df_empty(), target_table="db.table_b")
+    assert ctx.get_error_table_name == "db.table_b_error"  # Not "db.table_a_error"
+    assert ctx.get_error_table_name_user_specified is False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add logic to check for user-defined error table name from _context and assign the default error table name if none was provided

## Description
These code modifications allow the user to set a custom error table through the SparkExpectationsContext class. If no custom error table has been defined, the default behavior is retained. 

## Related Issue
https://github.com/Nike-Inc/spark-expectations/issues/256

## Motivation and Context
The error table was created in a schema that end-users expect refined views in. There was no option to specify a different schema for error tables so we've added a fully-qualified-name override 


## How Has This Been Tested?
One unit tests has been created to ensure the default behavior is retained, and another to ensure the over-ride fully qualified name is used.

## Screenshots (if appropriate):



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [X ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ X] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
