### PR TITLE
fix: NameError for environments without `spark-connect`

### DIFF
--- a/spark_expectations/core/expectations.py
+++ b/spark_expectations/core/expectations.py
@@ -64,11 +64,11 @@ if check_if_pyspark_connect_is_supported():
     from pyspark.sql.connect.dataframe import DataFrame as ConnectDataFrame
     from pyspark.sql.connect.session import SparkSession as ConnectSparkSession
 
-    DataFrame: TypeAlias = Union[sql.DataFrame, ConnectDataFrame]  # type: ignore
-    SparkSession: TypeAlias = Union[sql.SparkSession, ConnectSparkSession]  # type: ignore
+    DataFrame: TypeAlias = Union[sql.DataFrame, ConnectDataFrame]
+    SparkSession: TypeAlias = Union[sql.SparkSession, ConnectSparkSession]
 else:
-    DataFrame: TypeAlias = sql.DataFrame
-    SparkSession: TypeAlias = sql.SparkSession
+    DataFrame = sql.DataFrame # type: ignore
+    SparkSession = sql.SparkSession # type: ignore
 
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds condition to only define `TypeAlias`es for `ConnectDataFrame` and `ConnectSparkSession` when it's available.
This prevents runtime errors in environments where `spark-connect` is not available.

If the current `if check_if_pyspark_connect_is_supported()` returns False, then `ConnectDataFrame` and `ConnectSparkSession` are not defined, and the following `TypeAlias`es will fail.

## Related Issue
#248 
To reproduce the issue, you can install a connect supported pyspark version, e.g. `pyspark==3.5.1` but without `connect` feature flag. Then run a test-script:

`hatch run dev.py3.11:python mre.py`

**mre.py**
```python
from spark_expectations.core.expectations import SparkExpectations
```

Which raises the error:
```sh
Traceback (most recent call last):
  File "/mnt/nvme01/repos/spark-expectations/mre.py", line 1, in <module>
    from spark_expectations.core.expectations import SparkExpectations
  File "/mnt/nvme01/repos/spark-expectations/spark_expectations/core/expectations.py", line 67, in <module>
    DataFrame: TypeAlias = Union[sql.DataFrame, ConnectDataFrame]  # type: ignore
                                                ^^^^^^^^^^^^^^^^
```

## Motivation and Context
It makes it possible to use `spark-expectations` with newer versions of pyspark but without spark-connect.

## How Has This Been Tested?
I added the condition and reran `hatch run dev.py3.11:python mre.py`. Then I ran `make check` and `make test` which also passed.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
