### PR TITLE
Cast string to double to avoid division error

### DIFF
--- a/spark_expectations/sinks/utils/report.py
+++ b/spark_expectations/sinks/utils/report.py
@@ -333,7 +333,7 @@ class SparkExpectationsReport:
                 .withColumnRenamed("source_dq_error_row_count", "failed_records")
                 .withColumn(
                     "success_percentage",
-                    (col("valid_records") / col("total_records")) * 100,
+                    (col("valid_records").cast("double") / col("total_records").cast("double")) * 100,
                 )
             )
 

--- a/tests/integration/sinks/utils/test_report.py
+++ b/tests/integration/sinks/utils/test_report.py
@@ -33,18 +33,18 @@ def test_dq_obs_report_data_insert():
             StructField("source_dq_status", StringType(), True),
             StructField("source_dq_actual_outcome", StringType(), True),
             StructField("source_dq_expected_outcome", StringType(), True),
-            StructField("source_dq_actual_row_count", IntegerType(), True),
-            StructField("source_dq_error_row_count", IntegerType(), True),
-            StructField("source_dq_row_count", IntegerType(), True),
+            StructField("source_dq_actual_row_count", StringType(), True),
+            StructField("source_dq_error_row_count", StringType(), True),
+            StructField("source_dq_row_count", StringType(), True),
             StructField("source_dq_start_time", StringType(), True),
             StructField("source_dq_end_time", StringType(), True),
             StructField("target_expectations", StringType(), True),
             StructField("target_dq_status", StringType(), True),
             StructField("target_dq_actual_outcome", StringType(), True),
             StructField("target_dq_expected_outcome", StringType(), True),
-            StructField("target_dq_actual_row_count", IntegerType(), True),
-            StructField("target_dq_error_row_count", IntegerType(), True),
-            StructField("target_dq_row_count", IntegerType(), True),
+            StructField("target_dq_actual_row_count", StringType(), True),
+            StructField("target_dq_error_row_count", StringType(), True),
+            StructField("target_dq_row_count", StringType(), True),
             StructField("target_dq_start_time", StringType(), True),
             StructField("target_dq_end_time", StringType(), True),
             StructField("dq_date", StringType(), True),
@@ -52,6 +52,7 @@ def test_dq_obs_report_data_insert():
             StructField("dq_job_metadata_info", StringType(), True),
         ]
     )
+    # when _create_schema runs to create this DataFrame, all fields are StringType
 
     # Create data
     data = [
@@ -74,8 +75,8 @@ def test_dq_obs_report_data_insert():
             "1",
             ">3",
             None,
-            8,
-            8,
+            "8",
+            "8",
             "2025-02-11 00:07:39",
             "2025-02-11 00:07:40",
             None,
@@ -107,9 +108,9 @@ def test_dq_obs_report_data_insert():
             "pass",
             "0",
             "0",
-            100,
-            0,
-            100,
+            "100",
+            "0",
+            "100",
             "2025-02-11 00:08:39",
             "2025-02-11 00:08:40",
             None,
@@ -143,9 +144,9 @@ def test_dq_obs_report_data_insert():
             "fail",
             "5",
             "0",
-            95,
-            5,
-            100,
+            "95",
+            "5",
+            "100",
             "2025-02-11 00:09:39",
             "2025-02-11 00:09:40",
             None,
@@ -177,9 +178,9 @@ def test_dq_obs_report_data_insert():
             "pass",
             "0",
             "0",
-            100,
-            0,
-            100,
+            "100",
+            "0",
+            "100",
             "2025-02-11 00:10:39",
             "2025-02-11 00:10:40",
             None,
@@ -368,9 +369,9 @@ def test_dataframe_schema(test_dq_obs_report_data_insert):
             StructField("product_id", StringType(), True),
             StructField("table_name", StringType(), True),
             StructField("status", StringType(), True),
-            StructField("total_records", LongType(), True),
+            StructField("total_records", StringType(), True),
             StructField("failed_records", LongType(), True),
-            StructField("valid_records", LongType(), True),
+            StructField("valid_records", StringType(), True),
             StructField("success_percentage", DoubleType(), True),
             StructField("run_id", StringType(), True),
             StructField("job", StringType(), True),
@@ -397,3 +398,323 @@ def test_failed_records_greater_than_zero(test_dq_obs_report_data_insert):
     assert (
         test_df.filter(test_df["failed_records"].cast("int") < 0).count() == 0
     ), "failed_records should not  be less  than 0"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and tests for StringType row-count columns (production schema).
+#
+# In production, _create_schema (writer.py) creates all detailed-stats
+# columns as StringType.  The tests above use IntegerType which silently
+# allows arithmetic; the tests below prove the .cast("double") fix in
+# report.py works when the columns arrive as strings.
+# ---------------------------------------------------------------------------
+
+
+def _build_string_typed_detailed_df(extra_rows=None):
+    """Helper that builds a detailed-stats DataFrame with StringType row-count
+    columns, matching the production schema produced by _create_schema."""
+    schema = StructType(
+        [
+            StructField("run_id", StringType(), True),
+            StructField("product_id", StringType(), True),
+            StructField("table_name", StringType(), True),
+            StructField("rule_type", StringType(), True),
+            StructField("rule", StringType(), True),
+            StructField("column_name", StringType(), True),
+            StructField("source_expectations", StringType(), True),
+            StructField("tag", StringType(), True),
+            StructField("description", StringType(), True),
+            StructField("source_dq_status", StringType(), True),
+            StructField("source_dq_actual_outcome", StringType(), True),
+            StructField("source_dq_expected_outcome", StringType(), True),
+            StructField("source_dq_actual_row_count", StringType(), True),
+            StructField("source_dq_error_row_count", StringType(), True),
+            StructField("source_dq_row_count", StringType(), True),
+            StructField("source_dq_start_time", StringType(), True),
+            StructField("source_dq_end_time", StringType(), True),
+            StructField("target_expectations", StringType(), True),
+            StructField("target_dq_status", StringType(), True),
+            StructField("target_dq_actual_outcome", StringType(), True),
+            StructField("target_dq_expected_outcome", StringType(), True),
+            StructField("target_dq_actual_row_count", StringType(), True),
+            StructField("target_dq_error_row_count", StringType(), True),
+            StructField("target_dq_row_count", StringType(), True),
+            StructField("target_dq_start_time", StringType(), True),
+            StructField("target_dq_end_time", StringType(), True),
+            StructField("dq_date", StringType(), True),
+            StructField("dq_time", StringType(), True),
+            StructField("dq_job_metadata_info", StringType(), True),
+        ]
+    )
+
+    data = [
+        (
+            "your_product_1aacbbd4-e7de-11ef-bac4-4240eb7a97f9",
+            "your_product",
+            "dq_spark_dev.customer_order",
+            "query_dq",
+            "product_missing_count_threshold",
+            "testing_sample",
+            "SELECT 1",
+            "validity",
+            "row count threshold",
+            "fail",
+            "1",
+            ">3",
+            None,
+            "8",
+            "8",
+            "2025-02-11 00:07:39",
+            "2025-02-11 00:07:40",
+            None, None, None, None, None, None, None, None, None,
+            "2025-02-10",
+            "2025-02-11 00:07:46",
+            "{'job': 'test_job', 'Region': 'NA', 'Snapshot': '2024-04-15', 'data_object_name': 'customer_order'}",
+        ),
+        (
+            "your_product_2aacbbd4-e7de-11ef-bac4-4240eb7a97f9",
+            "your_product",
+            "dq_spark_dev.customer_order",
+            "query_dq",
+            "order_date_check",
+            "order_date",
+            "SELECT 1",
+            "completeness",
+            "null check",
+            "pass",
+            "0",
+            "0",
+            "100",
+            "0",
+            "100",
+            "2025-02-11 00:08:39",
+            "2025-02-11 00:08:40",
+            None, None, None, None, None, None, None, None, None,
+            "2025-02-10",
+            "2025-02-11 00:08:46",
+            "{'job': 'test_job', 'Region': 'NA', 'Snapshot': '2024-04-15', 'data_object_name': 'customer_order'}",
+        ),
+        (
+            "your_product_3aacbbd4-e7de-11ef-bac4-4240eb7a97f9",
+            "your_product",
+            "dq_spark_dev.customer_order",
+            "query_dq",
+            "order_id_uniqueness",
+            "order_id",
+            "SELECT 1",
+            "uniqueness",
+            "duplicate check",
+            "fail",
+            "5",
+            "0",
+            "95",
+            "5",
+            "100",
+            "2025-02-11 00:09:39",
+            "2025-02-11 00:09:40",
+            None, None, None, None, None, None, None, None, None,
+            "2025-02-10",
+            "2025-02-11 00:09:46",
+            "{'job': 'test_job', 'Region': 'NA', 'Snapshot': '2024-04-15', 'data_object_name': 'customer_order'}",
+        ),
+    ]
+
+    if extra_rows:
+        data.extend(extra_rows)
+
+    return spark.createDataFrame(data, schema)
+
+
+def _build_custom_detailed_df():
+    """Builds the custom-detailed (query DQ) DataFrame used alongside the
+    detailed-stats DataFrame in the report fixture."""
+    schema = StructType(
+        [
+            StructField("run_id", StringType(), True),
+            StructField("product_id", StringType(), True),
+            StructField("table_name", StringType(), True),
+            StructField("rule", StringType(), True),
+            StructField("column_name", StringType(), True),
+            StructField("alias", StringType(), True),
+            StructField("dq_type", StringType(), True),
+            StructField("source_output", StringType(), True),
+            StructField("target_output", StringType(), True),
+            StructField("dq_time", StringType(), True),
+        ]
+    )
+
+    data = [
+        (
+            "your_product_a67e4db2-e7de-11ef-bb70-4240eb7a97f9",
+            "your_product",
+            "dq_spark_dev.customer_order",
+            "product_missing_count_threshold",
+            "testing_sample",
+            "source_f1",
+            "_source_dq",
+            (
+                '{source_f1=[{"product_id":"FUR-BO-10001798","order_id":"CA-2016-152156","order_date":"11/8/2016","count":1}]}'
+            ),
+            (
+                '{target_f1=[{"product_id":"FUR-BO-10001798","order_id":"CA-2016-152156","order_date":"11/8/2016","count":2}]}'
+            ),
+            "2025-02-11 00:11:41",
+        ),
+        (
+            "your_product_a67e4db2-e7de-11ef-bb70-4240eb7a97f9",
+            "your_product",
+            "dq_spark_dev.customer_order",
+            "product_missing_count_threshold",
+            "testing_sample",
+            "target_f1",
+            "_source_dq",
+            (
+                '{target_f1=[{"product_id":"FUR-BO-10001798","order_id":"CA-2016-152156","order_date":"11/8/2016","count":2}]}'
+            ),
+            "NULL",
+            "2025-02-11 00:11:41",
+        ),
+    ]
+
+    return spark.createDataFrame(data, schema)
+
+
+def _run_report(df_detailed, df_custom):
+    """Set up context, run the report, return (result_bool, result_df)."""
+    context = SparkExpectationsContext("product_id", spark)
+    context.set_stats_detailed_dataframe(df_detailed)
+    context.set_custom_detailed_dataframe(df_custom)
+    report = SparkExpectationsReport(context)
+    return report.dq_obs_report_data_insert()
+
+
+@pytest.fixture(scope="module")
+def string_typed_report():
+    """Fixture that exercises dq_obs_report_data_insert with StringType
+    row-count columns, matching the production schema."""
+    df_detailed = _build_string_typed_detailed_df()
+    df_custom = _build_custom_detailed_df()
+    return _run_report(df_detailed, df_custom)
+
+
+def test_report_string_typed_columns_no_error(string_typed_report):
+    """Core regression test: would have raised DATATYPE_MISMATCH before the
+    .cast('double') fix on (valid_records / total_records)."""
+    test_result, test_df = string_typed_report
+    assert test_result is True
+    assert isinstance(test_df, DataFrame)
+    assert test_df.count() > 0
+
+
+def test_report_string_typed_success_percentage_is_numeric(string_typed_report):
+    """success_percentage must be DoubleType with values in [0, 100]."""
+    _, test_df = string_typed_report
+
+    sp_field = next(f for f in test_df.schema.fields if f.name == "success_percentage")
+    assert sp_field.dataType == DoubleType(), (
+        f"Expected success_percentage to be DoubleType, got {sp_field.dataType}"
+    )
+
+    non_null_rows = test_df.filter(test_df["success_percentage"].isNotNull())
+    assert non_null_rows.filter(non_null_rows["success_percentage"] > 100).count() == 0, (
+        "success_percentage should not exceed 100"
+    )
+    assert non_null_rows.filter(non_null_rows["success_percentage"] < 0).count() == 0, (
+        "success_percentage should not be negative"
+    )
+
+
+def test_report_string_typed_columns_schema(string_typed_report):
+    """Verify the output has the expected columns and that the key computed
+    column (success_percentage) is DoubleType regardless of string inputs."""
+    _, test_df = string_typed_report
+
+    expected_columns = [
+        "rule", "column_name", "dq_time", "product_id", "table_name",
+        "status", "total_records", "failed_records", "valid_records",
+        "success_percentage", "run_id",
+        "job", "Region", "Snapshot", "data_object_name",
+    ]
+    for col_name in expected_columns:
+        assert col_name in test_df.columns, f"Missing expected column: {col_name}"
+
+    sp_field = next(f for f in test_df.schema.fields if f.name == "success_percentage")
+    assert sp_field.dataType == DoubleType()
+
+
+def test_report_with_null_string_row_counts():
+    """Null values in StringType row-count columns should produce null
+    success_percentage, not crash."""
+    null_row = (
+        "run_null_test",
+        "your_product",
+        "dq_spark_dev.customer_order",
+        "query_dq",
+        "null_check_rule",
+        "some_col",
+        "SELECT 1",
+        "validity",
+        "desc",
+        "fail",
+        "0",
+        "0",
+        None,   # source_dq_actual_row_count = null
+        "0",
+        None,   # source_dq_row_count = null
+        "2025-02-11 00:07:39",
+        "2025-02-11 00:07:40",
+        None, None, None, None, None, None, None, None, None,
+        "2025-02-10",
+        "2025-02-11 00:07:46",
+        "{'job': 'test_job', 'Region': 'NA', 'Snapshot': '2024-04-15', 'data_object_name': 'customer_order'}",
+    )
+
+    df_detailed = _build_string_typed_detailed_df(extra_rows=[null_row])
+    df_custom = _build_custom_detailed_df()
+
+    test_result, test_df = _run_report(df_detailed, df_custom)
+    assert test_result is True
+
+    null_run = test_df.filter(test_df["run_id"] == "run_null_test")
+    assert null_run.count() == 1
+    row = null_run.collect()[0]
+    assert row["success_percentage"] is None, (
+        "success_percentage should be null when both valid_records and total_records are null"
+    )
+
+
+def test_report_with_zero_string_total_records():
+    """Division by zero (total_records = '0') should produce null or inf,
+    not raise an exception."""
+    zero_row = (
+        "run_zero_test",
+        "your_product",
+        "dq_spark_dev.customer_order",
+        "query_dq",
+        "zero_total_rule",
+        "some_col",
+        "SELECT 1",
+        "validity",
+        "desc",
+        "fail",
+        "0",
+        "0",
+        "50",    # source_dq_actual_row_count (valid_records)
+        "50",
+        "0",     # source_dq_row_count (total_records) = 0 -> division by zero
+        "2025-02-11 00:07:39",
+        "2025-02-11 00:07:40",
+        None, None, None, None, None, None, None, None, None,
+        "2025-02-10",
+        "2025-02-11 00:07:46",
+        "{'job': 'test_job', 'Region': 'NA', 'Snapshot': '2024-04-15', 'data_object_name': 'customer_order'}",
+    )
+
+    df_detailed = _build_string_typed_detailed_df(extra_rows=[zero_row])
+    df_custom = _build_custom_detailed_df()
+
+    test_result, test_df = _run_report(df_detailed, df_custom)
+    assert test_result is True
+
+    zero_run = test_df.filter(test_df["run_id"] == "run_zero_test")
+    assert zero_run.count() == 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We got reported a bug creating an error: DATATYPE_MISMATCH.BINARY_OP_WRONG_TYPE. This was due to trying to divide StringType.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This update casts Strings to Doubles before the division.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated the unit tests to act the way the production code acts, with every field as a StringType.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
