### PR TITLE
Add Email Notification Details Page to MKDocs/GH Pages Docs

### DIFF
--- a/docs/user_guide/notifications/email_notification_types.md
+++ b/docs/user_guide/notifications/email_notification_types.md
@@ -4,7 +4,7 @@ Spark Expectations can send three kinds of emails.
 
 ## 1. Data Quality Report Emails
 
-Please see the [Observability Examples doc](Observability_examples.md) for more detailed information on emails that contain the DQ report.
+Please see the [Observability Examples doc](../../Observability_examples.md) for more detailed information on emails that contain the DQ report.
 
 
 ## 2. Basic Email Notifications/Alerts
@@ -229,5 +229,5 @@ user_config.se_notifications_email_custom_template: ""
 As seen in the template, some of the results values are nested data structures (often an array of maps/dicts) and their elements can be accessed directly with the right syntax, or using `for` loops or other options that Jinja2 supports.
 
 __Note:__
-- If an empty string `""` is passed in to the template field in the user config, the default template will be used: ([spark_expectations/config/templates/custom_email_alert_template.jinja](../spark_expectations/config/templates/custom_email_alert_template.jinja)).
+- If an empty string `""` is passed in to the template field in the user config, the default template will be used: ([spark_expectations/config/templates/custom_email_alert_template.jinja](../../../spark_expectations/config/templates/custom_email_alert_template.jinja)).
 - A metric name must be specified in `user_config.se_notifications_email_custom_body` if it is being referenced in the template. For example, if `{{ final_agg_dq_results }}` is referenced in the template, then `"'final_agg_dq_results': {},\n "` must be in the user config.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,9 @@ nav:
               - Example Config: user_guide/user_config/user_config.md
               - Kafka Custom Config: user_guide/user_config/kafka_custom_config.md
           - Notifications:
-              - Email: user_guide/notifications/email_notifications.md
+              - Email:
+                  - Email Notification Config: user_guide/notifications/email_notifications.md
+                  - Email Notification Types: user_guide/notifications/email_notification_types.md
               - Slack: user_guide/notifications/slack_notifications.md
               - PagerDuty: user_guide/notifications/pagerduty_notifications.md
           - Observability: Observability_examples.md


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This page specifying email notifications types and other details was in the docs directory but wasn't referenced in the MKDocs config, so it wasn't showing up in SE Github Pages docs. This fixes that.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Makes that docs info more findable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `make docs` locally & checked what the output looked like.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
