### PR TITLE
add ansi-safe casting

### DIFF
--- a/docs/user_guide/data_quality_rules.md
+++ b/docs/user_guide/data_quality_rules.md
@@ -106,6 +106,7 @@ ADD CONSTRAINT action CHECK (
 **Tip:**  
 - Match your expectation format to the rule type for correct validation.
 - Use `row_dq` for per-row checks, `agg_dq` for summary statistics, and `query_dq` for advanced SQL-based checks.
+- If running in Databricks serverless compute, expectations need to be ANSI compliant. See the ANSI Mode section of the [Serverless doc](serverless.md) for details.
 
 
 Below are the details and examples for each rule type:

--- a/docs/user_guide/serverless.md
+++ b/docs/user_guide/serverless.md
@@ -66,3 +66,9 @@ def process_data():
 result_df = process_data()
 ```
 
+### IMPORTANT: ANSI Mode
+When using serverless compute on Databricks, ANSI mode is **on by default**, which enforces stricter standards. If you use serverless compute you have two options:
+- Turn ANSI mode off: set `spark.sql.ansi.enabled` to `false`
+- Or, make sure your expectations are written in an ANSI-compliant way
+    - Use `try_cast` instead of `CAST`
+    - Please see Databricks documentation on ANSI mode for more guidance on other requirements for ANSI compliance

--- a/spark_expectations/core/exceptions.py
+++ b/spark_expectations/core/exceptions.py
@@ -80,3 +80,13 @@ class SparkExpectationsInvalidAggDQExpectationException(Exception):
     """
     Throw this exception when an invalid agg_dq expectation is encountered
     """
+
+def raise_if_ansi_exception(e: Exception, rule_name: str, rule_expectation: str) -> None:
+    """Check if exception is likely cast error due to ANSI mode. Add that info to error message and raise."""
+    if "CAST_INVALID_INPUT" in str(e):
+        raise SparkExpectationsMiscException(
+            f"Cast error while evaluating rule '{rule_name}' with expectation/SQL '{rule_expectation}'. "
+            f"This may be caused by rule expectation/SQL incompatibility with spark.sql.ansi.enabled=true "
+            f"(default on Databricks Serverless). Please either update your expectation/SQL "
+            f"to be compliant with ANSI mode, disable ANSI mode, or run not on serverless."
+        ) from e

--- a/spark_expectations/sinks/utils/report.py
+++ b/spark_expectations/sinks/utils/report.py
@@ -204,11 +204,11 @@ class SparkExpectationsReport:
                                 100 
                                 * least(
                                         abs(valid_records_only_nbr),
-                                        abs(total_records_only_nbr),
+                                        abs(total_records_only_nbr)
                                     ) / nullif(
                                             greatest(
                                                 abs(valid_records_only_nbr),
-                                                abs(total_records_only_nbr),
+                                                abs(total_records_only_nbr)
                                             ),
                                             0
                                         )

--- a/spark_expectations/sinks/utils/report.py
+++ b/spark_expectations/sinks/utils/report.py
@@ -14,17 +14,15 @@ from pyspark.sql.functions import (
     size,
     concat_ws,
     abs,
-    least,
-    greatest,
     get_json_object,
     lit,
-    trim,
 )
-from pyspark.sql.types import DoubleType, StringType, DecimalType, TimestampType
+from pyspark.sql.types import DoubleType, StringType, TimestampType
 
 from spark_expectations import _log
 from spark_expectations.core.context import SparkExpectationsContext
 from spark_expectations.core.exceptions import SparkExpectationsMiscException
+from spark_expectations.utils.udf import safe_cast
 
 
 @dataclass
@@ -176,7 +174,7 @@ class SparkExpectationsReport:
                 .withColumn(
                     "total_records_only_nbr",
                     when(col("_total_records_str") == "", lit(None).cast("bigint"))
-                    .otherwise(col("_total_records_str").cast("bigint")),
+                    .otherwise(safe_cast(self.spark, "_total_records_str", "bigint")),
                 )
                 .withColumn(
                     "_valid_records_str",
@@ -185,7 +183,7 @@ class SparkExpectationsReport:
                 .withColumn(
                     "valid_records_only_nbr",
                     when(col("_valid_records_str") == "", lit(None).cast("bigint"))
-                    .otherwise(col("_valid_records_str").cast("bigint")),
+                    .otherwise(safe_cast(self.spark, "_valid_records_str", "bigint")),
                 )
                 .drop("_total_records_str", "_valid_records_str")
                 .withColumn(
@@ -195,26 +193,29 @@ class SparkExpectationsReport:
                         lit(100),
                     )
                     .when(
-                        col("total_records_only_nbr").isNull() & col("valid_records_only_nbr").isNull(),
-                        lit(100),
-                    )
-                    .when(
                         col("total_records_only_nbr").isNotNull() & col("valid_records_only_nbr").isNull(),
                         lit(0),
                     )
                     .otherwise(
                         coalesce(
-                            (
-                                100
+                            safe_cast(
+                                self.spark,
+                                """
+                                100 
                                 * least(
-                                    abs(trim(col("valid_records_only_nbr"))),
-                                    abs(trim(col("total_records_only_nbr"))),
-                                )
-                                / greatest(
-                                    abs(trim(col("valid_records_only_nbr"))),
-                                    abs(trim(col("total_records_only_nbr"))),
-                                )
-                            ).cast(DecimalType(20, 2)),
+                                        abs(valid_records_only_nbr),
+                                        abs(total_records_only_nbr),
+                                    ) / nullif(
+                                            greatest(
+                                                abs(valid_records_only_nbr),
+                                                abs(total_records_only_nbr),
+                                            ),
+                                            0
+                                        )
+                                """,
+                                "decimal(20, 2)"
+                            )
+                            ,
                             lit(0),
                         )
                     ),
@@ -222,10 +223,6 @@ class SparkExpectationsReport:
                 .withColumn(
                     "failed_rec_perc_variance",
                     when(
-                        col("total_records_only_nbr").isNull() & col("valid_records_only_nbr").isNull(),
-                        lit(0),
-                    )
-                    .when(
                         col("total_records_only_nbr").isNull() & col("valid_records_only_nbr").isNull(),
                         lit(0),
                     )
@@ -255,11 +252,11 @@ class SparkExpectationsReport:
                     abs(
                         coalesce(
                             coalesce(
-                                trim(col("total_records_only_nbr")).cast("bigint"),
+                                col("total_records_only_nbr"),
                                 lit(0),
                             )
                             - coalesce(
-                                trim(col("valid_records_only_nbr")).cast("bigint"),
+                                col("valid_records_only_nbr"),
                                 lit(0),
                             ),
                             lit(0),
@@ -333,7 +330,7 @@ class SparkExpectationsReport:
                 .withColumnRenamed("source_dq_error_row_count", "failed_records")
                 .withColumn(
                     "success_percentage",
-                    (col("valid_records").cast("double") / col("total_records").cast("double")) * 100,
+                    (safe_cast(self.spark, "valid_records", "double") / safe_cast(self.spark, "total_records", "double")) * 100,
                 )
             )
 

--- a/spark_expectations/utils/actions.py
+++ b/spark_expectations/utils/actions.py
@@ -21,6 +21,7 @@ from spark_expectations.core.context import SparkExpectationsContext
 from spark_expectations.core.exceptions import (
     SparkExpectationsMiscException,
     SparkExpectOrFailException,
+    raise_if_ansi_exception
 )
 from spark_expectations.utils.udf import get_actions_list, remove_empty_maps
 
@@ -174,8 +175,11 @@ class SparkExpectationsActions:
                         _agg_dq_expectation_aggstring = _agg_dq_expectation_match.group(1)
                         _agg_dq_expectation_expr = _agg_dq_expectation_match.group(2)
                         _agg_dq_expectation_cond_expr = expr(_agg_dq_expectation_aggstring)
-
-                        _agg_dq_actual_count_value_raw = df.agg(_agg_dq_expectation_cond_expr).collect()[0][0]
+                        try:
+                            _agg_dq_actual_count_value_raw = df.agg(_agg_dq_expectation_cond_expr).collect()[0][0]
+                        except Exception as e:
+                            raise_if_ansi_exception(e, _dq_rule["rule"], _dq_rule["expectation"])
+                            raise
 
                         # Handle NoneType (nulls)
                         if _agg_dq_actual_count_value_raw is None:
@@ -252,7 +256,11 @@ class SparkExpectationsActions:
 
                         _agg_dq_expectation_cond_expr = expr(_agg_dq_expectation_aggstring)
 
-                        _agg_dq_actual_count_value = int(df.agg(_agg_dq_expectation_cond_expr).collect()[0][0])
+                        try:
+                            _agg_dq_actual_count_value = int(df.agg(_agg_dq_expectation_cond_expr).collect()[0][0])
+                        except Exception as e:
+                            raise_if_ansi_exception(e, _dq_rule["rule"], _agg_dq_expectation_aggstring)
+                            raise
 
                         _agg_dq_expression_str_lower = (
                             str(_agg_dq_actual_count_value) + _agg_dq_expectation_expr_lowerbound
@@ -319,7 +327,11 @@ class SparkExpectationsActions:
                     )
                 ):
                     for _key, _querydq_query in sub_key_value.items():
-                        _querydq_df = _context.spark.sql(_dq_rule["expectation" + "_" + _key])
+                        try:
+                            _querydq_df = _context.spark.sql(_dq_rule["expectation" + "_" + _key])
+                        except Exception as e:
+                            raise_if_ansi_exception(e, _dq_rule["rule"], _dq_rule["expectation" + "_" + _key])
+                            raise
                         querydq_output.append(
                             (
                                 _context.get_run_id,
@@ -357,7 +369,15 @@ class SparkExpectationsActions:
                         def execute_sql_and_get_result(
                             _se_context: SparkExpectationsContext, query: str
                         ) -> Union[int, float, str]:
-                            return _se_context.spark.sql(f"SELECT ({query}) AS OUTPUT").collect()[0][0] if query else 0
+                            if query:
+                                try:
+                                    result = _se_context.spark.sql(f"SELECT ({query}) AS OUTPUT").collect()[0][0]
+                                except Exception as e:
+                                    raise_if_ansi_exception(e, _dq_rule["rule"], f"SELECT ({query}) AS OUTPUT")
+                                    raise
+                            else:
+                                result = 0
+                            return result
 
                         # function to get the query outputs
                         _querydq_source_query_output = execute_sql_and_get_result(_context, match.group(1))
@@ -380,8 +400,12 @@ class SparkExpectationsActions:
 
                 _querydq_status_query = "SELECT (" + str(_dq_rule["expectation"]) + ") AS OUTPUT"
 
-                _query_dq_result = int(_context.spark.sql(_querydq_status_query).collect()[0][0])
-
+                try:
+                    _query_dq_result = int(_context.spark.sql(_querydq_status_query).collect()[0][0])
+                except Exception as e:
+                    raise_if_ansi_exception(e, _dq_rule["rule"], _querydq_status_query)
+                    raise
+                
                 status = "pass" if _query_dq_result else "fail"
 
                 if _source_dq_status:

--- a/spark_expectations/utils/udf.py
+++ b/spark_expectations/utils/udf.py
@@ -1,5 +1,5 @@
-from pyspark.sql import Column
-from pyspark.sql.functions import filter, size, transform, when, lit, array
+from pyspark.sql import SparkSession, Column
+from pyspark.sql.functions import filter, size, transform, when, lit, array, expr
 
 
 def remove_empty_maps(column: Column) -> Column:
@@ -40,3 +40,20 @@ def get_actions_list(column: Column) -> Column:
     column = remove_passing_status_maps(column)
     action_if_failed = transform(column, lambda x: x["action_if_failed"])
     return when(size(action_if_failed) == 0, array(lit("ignore"))).otherwise(action_if_failed)  # pragma: no cover
+
+def safe_cast(spark: SparkSession, column: str, target_type: str) -> Column:
+    """
+    Checks if ANSI mode is enabled. If enabled, uses try_cast to cast the column to the target type. If not, uses cast.
+    Args:
+        spark: SparkSession
+        column: column to cast (provided as a string)
+        target_type: target type to cast to
+
+    Returns:
+        Column: the casted column
+    """
+    ansi_enabled = spark.conf.get("spark.sql.ansi.enabled", "false").lower() == "true"
+    if ansi_enabled:
+        return expr(f"try_cast({column} as {target_type})")
+    else: 
+        return expr(f"cast({column} as {target_type})")

--- a/tests/integration/utils/test_udf.py
+++ b/tests/integration/utils/test_udf.py
@@ -1,5 +1,6 @@
+from pyspark.sql.types import LongType, DoubleType
 from spark_expectations.core import get_spark_session
-from spark_expectations.utils.udf import remove_empty_maps, get_actions_list
+from spark_expectations.utils.udf import remove_empty_maps, get_actions_list, safe_cast
 
 spark = get_spark_session()
 
@@ -57,3 +58,42 @@ def test_get_actions_list():
 
     for itr in range(0, 4):
         assert results[itr].actions == expected_output[itr]
+
+def test_safe_cast_ansi_disabled():
+    # with default spark.sql.ansi.enabled=false, safe cast should return
+    #  a column equavalent to cast(col as type)
+    spark.conf.set("spark.sql.ansi.enabled", "false")
+
+    columns = ["Name", "Value"]
+    data = [("thing", "123")]
+    df = spark.createDataFrame(data, schema=columns)
+
+    result_df = df.withColumn("casted_value", safe_cast(spark, "Value", "bigint"))
+    result = result_df.select("casted_value").collect()[0]["casted_value"]
+
+    assert result == 123
+    assert result_df.schema["casted_value"].dataType == LongType()
+
+
+def test_safe_cast_ansi_enabled():
+    # with spark.sql.ansi.enabled=true, safe cast should succeed if it's a castable value and should 
+    #  return Null if it's not a valid cast (without safe cast it would throw an exception insead)
+    spark.conf.set("spark.sql.ansi.enabled", "true")
+
+    columns = ["Name", "Value", "Color"]
+    data = [("mug", "10", "red")]
+    df = spark.createDataFrame(data, schema=columns)
+
+    success_result_df = df.withColumn("success_casted_value", safe_cast(spark, "Value", "double"))
+    success_result = success_result_df.select("success_casted_value").collect()[0]["success_casted_value"]
+
+    fail_result_df = df.withColumn("fail_casted_value", safe_cast(spark, "Color", "double"))
+    fail_result = fail_result_df.select("fail_casted_value").collect()[0]["fail_casted_value"]
+
+    # re-set ansi mode so it doesn't affect other tests
+    spark.conf.set("spark.sql.ansi.enabled", "false")
+
+    assert success_result == 10
+    assert success_result_df.schema["success_casted_value"].dataType == DoubleType()
+
+    assert fail_result is None

--- a/tests/unit/core/test_expectations.py
+++ b/tests/unit/core/test_expectations.py
@@ -3,7 +3,7 @@ Unit tests for spark_expectations.core.expectations module.
 """
 import pytest
 
-from spark_expectations.core.exceptions import SparkExpectationsUserInputOrConfigInvalidException
+from spark_expectations.core.exceptions import SparkExpectationsMiscException, SparkExpectationsUserInputOrConfigInvalidException, raise_if_ansi_exception
 from spark_expectations.core.expectations import SparkExpectations, WrappedDataFrameWriter
 
 
@@ -472,3 +472,30 @@ class TestAddHashColumns:
         assert row["id_hash"] is not None
         assert len(row["id_hash"]) == 32
         assert all(c in "0123456789abcdef" for c in row["id_hash"])
+
+
+class TestRaiseIfAnsiException:
+    """Test cases for SparkExpectations exception raise_if_ansi_exception method."""
+
+    def test_raise_if_ansi_exception(self):
+        ansi_exception = Exception("SparkExpectationsMiscException: error occurred while processing spark expectations"
+        " error occurred while executing func_process error occurred while running expectations error occurred"
+        " while running agg_query_dq_detailed_result [CAST_INVALID_INPUT] The value '' of the type \"STRING\""
+        " cannot be cast to \"BIGINT\" because it is malformed. Correct the value as per the syntax, or change its"
+        " target type. Use `try_cast` to tolerate malformed input and return NULL instead.")
+
+        rule_name = "Column A Greater than Column B"
+        rule_expectation = "[col_A] > [col_B]"
+
+        with pytest.raises(SparkExpectationsMiscException) as exception_info:
+            raise_if_ansi_exception(ansi_exception, rule_name, rule_expectation)
+        
+        assert f"{rule_name}" in str(exception_info.value)
+        assert f"{rule_expectation}" in str(exception_info.value)
+
+    def test_no_raise_ansi_exception(self):
+        non_ansi_exception = Exception("Exception message about some things that are not related to ANSI casting.")
+
+        result = raise_if_ansi_exception(non_ansi_exception, "Foo", "Bar")
+
+        assert result is None

--- a/tests/unit/utils/test_actions.py
+++ b/tests/unit/utils/test_actions.py
@@ -317,9 +317,6 @@ def test_agg_query_dq_detailed_result_ansi_sql_query(_fixture_agg_dq_rule):
     #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
     #   expectation must match pattern = rf"({left_expr})\s*({operator})\s*({right_value}|({right_expr}))|({left_expr})"
 
-    actions = Mock(spec=SparkExpectationsActions)
-    actions.match_parentheses = True
-
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
     ctx.get_query_dq_rule_type_name = "query_dq"
@@ -348,9 +345,6 @@ def test_agg_query_dq_detailed_result_not_ansi_sql_query(_fixture_agg_dq_rule):
     #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
     #   expectation must match pattern = rf"({left_expr})\s*({operator})\s*({right_value}|({right_expr}))|({left_expr})"
 
-    actions = Mock(spec=SparkExpectationsActions)
-    actions.match_parentheses = True
-
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
     ctx.get_query_dq_rule_type_name = "query_dq"
@@ -369,13 +363,66 @@ def test_agg_query_dq_detailed_result_not_ansi_sql_query(_fixture_agg_dq_rule):
     with pytest.raises(SparkExpectationsMiscException):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
 
+###########
+def test_agg_query_dq_detailed_result_ansi_sql_compare(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
+    #   expectation must match pattern = rf"({left_expr})\s*({operator})\s*({right_value}|({right_expr}))|({left_expr})"
+
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.spark = Mock()
+    ctx.get_query_dq_rule_type_name = "query_dq"
+    ctx.get_query_dq_detailed_stats_status = True
+
+    ctx.spark.sql.side_effect = Exception(
+        "[CAST_INVALID_INPUT] The value '' of the type \"STRING\" cannot be cast"
+        " to \"BIGINT\" because it is malformed. Correct the value as per the"
+        " syntax, or change its target type. Use `try_cast` to tolerate malformed"
+        " input and return NULL instead.")
+
+    _fixture_agg_dq_rule["rule_type"] = "query_dq"
+    _fixture_agg_dq_rule["expectation"] = "(\"SELECT COUNT(*) FROM order_source\") >= 5"
+    _fixture_agg_dq_rule["enable_querydq_custom_output"] = False
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
+
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+
+
+def test_agg_query_dq_detailed_result_not_ansi_sql_compare(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
+    #   expectation must match pattern = rf"({left_expr})\s*({operator})\s*({right_value}|({right_expr}))|({left_expr})"
+
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.spark = Mock()
+    ctx.get_query_dq_rule_type_name = "query_dq"
+    ctx.get_query_dq_detailed_stats_status = True
+
+    ctx.spark.sql.side_effect = Exception("Some other error message not having to do with ANSI casting.")
+
+    _fixture_agg_dq_rule["rule_type"] = "query_dq"
+    _fixture_agg_dq_rule["expectation"] = "(\"SELECT COUNT(*) FROM order_source\") >= 5"
+    _fixture_agg_dq_rule["enable_querydq_custom_output"] = False
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
+
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+#############
+
 
 def test_agg_query_dq_detailed_result_ansi_sql_query_post(_fixture_agg_dq_rule):
     # testing the following conditions in agg_query_dq_detailed_result:
     #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
 
-    actions = Mock(spec=SparkExpectationsActions)
-    actions.match_parentheses = True
 
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
@@ -406,8 +453,6 @@ def test_agg_query_dq_detailed_result_not_ansi_sql_query_post(_fixture_agg_dq_ru
     # testing the following conditions in agg_query_dq_detailed_result:
     #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
 
-    actions = Mock(spec=SparkExpectationsActions)
-    actions.match_parentheses = True
 
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()

--- a/tests/unit/utils/test_actions.py
+++ b/tests/unit/utils/test_actions.py
@@ -261,8 +261,8 @@ def test_agg_query_dq_detailed_result_ansi_custom_query(_fixture_agg_dq_rule):
 
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
-    ctx.get_agg_dq_rule_type_name = "query_dq"
-    ctx.get_agg_dq_detailed_stats_status = True
+    ctx.get_query_dq_rule_type_name = "query_dq"
+    ctx.get_query_dq_detailed_stats_status = True
     ctx.get_querydq_secondary_queries = {
         "product_1|test_table|col1_sum_gt_eq_6": {"source_f1": "some_query"}
     }
@@ -280,9 +280,37 @@ def test_agg_query_dq_detailed_result_ansi_custom_query(_fixture_agg_dq_rule):
     mock_agg_result = MagicMock()
     mock_df.agg.return_value = mock_agg_result
 
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+
+
+def test_agg_query_dq_detailed_result_not_ansi_custom_query(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   _dq_rule["rule_type"] == _context.get_query_dq_rule_type_name #("query_dq")
+    #   _context.get_agg_dq_detailed_stats_status is True
+    #   if (_dq_rule["enable_querydq_custom_output"])
+    #   sub_key_value := _querydq_secondary_query.get(_dq_rule["product_id"] + "|" + _dq_rule["table_name"] + "|" + _dq_rule["rule"], {},)
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.spark = Mock()
+    ctx.get_query_dq_rule_type_name = "query_dq"
+    ctx.get_query_dq_detailed_stats_status = True
+    ctx.get_querydq_secondary_queries = {
+        "product_1|test_table|col1_sum_gt_eq_6": {"source_f1": "some_query"}
+    }
+    ctx.spark.sql.side_effect = Exception("Some other error message not having to do with ANSI casting.")
+
+    _fixture_agg_dq_rule["rule_type"] = "query_dq"
+    _fixture_agg_dq_rule["enable_querydq_custom_output"] = True
+    _fixture_agg_dq_rule["expectation_source_f1"] = "SELECT * FROM table"
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
 
     with pytest.raises(SparkExpectationsMiscException):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+
 
 def test_agg_query_dq_detailed_result_ansi_sql_query(_fixture_agg_dq_rule):
     # testing the following conditions in agg_query_dq_detailed_result:
@@ -294,14 +322,41 @@ def test_agg_query_dq_detailed_result_ansi_sql_query(_fixture_agg_dq_rule):
 
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
-    ctx.get_agg_dq_rule_type_name = "query_dq"
-    ctx.get_agg_dq_detailed_stats_status = True
+    ctx.get_query_dq_rule_type_name = "query_dq"
+    ctx.get_query_dq_detailed_stats_status = True
 
     ctx.spark.sql.side_effect = Exception(
         "[CAST_INVALID_INPUT] The value '' of the type \"STRING\" cannot be cast"
         " to \"BIGINT\" because it is malformed. Correct the value as per the"
         " syntax, or change its target type. Use `try_cast` to tolerate malformed"
         " input and return NULL instead.")
+
+    _fixture_agg_dq_rule["rule_type"] = "query_dq"
+    _fixture_agg_dq_rule["expectation"] = "(\"SELECT COUNT(*) FROM order_source WHERE order_date IS NULL\")"
+    _fixture_agg_dq_rule["enable_querydq_custom_output"] = False
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
+
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+
+
+def test_agg_query_dq_detailed_result_not_ansi_sql_query(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
+    #   expectation must match pattern = rf"({left_expr})\s*({operator})\s*({right_value}|({right_expr}))|({left_expr})"
+
+    actions = Mock(spec=SparkExpectationsActions)
+    actions.match_parentheses = True
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.spark = Mock()
+    ctx.get_query_dq_rule_type_name = "query_dq"
+    ctx.get_query_dq_detailed_stats_status = True
+
+    ctx.spark.sql.side_effect = Exception("Some other error message not having to do with ANSI casting.")
 
     _fixture_agg_dq_rule["rule_type"] = "query_dq"
     _fixture_agg_dq_rule["expectation"] = "(\"SELECT COUNT(*) FROM order_source WHERE order_date IS NULL\")"
@@ -324,8 +379,8 @@ def test_agg_query_dq_detailed_result_ansi_sql_query_post(_fixture_agg_dq_rule):
 
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
-    ctx.get_agg_dq_rule_type_name = "query_dq"
-    ctx.get_agg_dq_detailed_stats_status = True
+    ctx.get_query_dq_rule_type_name = "query_dq"
+    ctx.get_query_dq_detailed_stats_status = True
 
 
     first_result = MagicMock()
@@ -337,6 +392,38 @@ def test_agg_query_dq_detailed_result_ansi_sql_query_post(_fixture_agg_dq_rule):
         " to \"BIGINT\" because it is malformed. Correct the value as per the"
         " syntax, or change its target type. Use `try_cast` to tolerate malformed"
         " input and return NULL instead."),
+    ]
+
+    _fixture_agg_dq_rule["rule_type"] = "query_dq"
+    _fixture_agg_dq_rule["expectation"] = "(\"SELECT COUNT(*) FROM order_source WHERE order_date IS NULL\")"
+    _fixture_agg_dq_rule["enable_querydq_custom_output"] = False
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
+
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+
+
+def test_agg_query_dq_detailed_result_not_ansi_sql_query_post(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
+
+    actions = Mock(spec=SparkExpectationsActions)
+    actions.match_parentheses = True
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.spark = Mock()
+    ctx.get_query_dq_rule_type_name = "query_dq"
+    ctx.get_query_dq_detailed_stats_status = True
+
+
+    first_result = MagicMock()
+    first_result.collect.return_value = [[42]]
+    ctx.spark.sql.side_effect = [
+        first_result,
+        Exception("Some other error message not having to do with ANSI casting."),
     ]
 
     _fixture_agg_dq_rule["rule_type"] = "query_dq"

--- a/tests/unit/utils/test_actions.py
+++ b/tests/unit/utils/test_actions.py
@@ -382,11 +382,7 @@ def test_agg_query_dq_detailed_result_ansi_sql_query_post(_fixture_agg_dq_rule):
     ctx.get_query_dq_rule_type_name = "query_dq"
     ctx.get_query_dq_detailed_stats_status = True
 
-
-    first_result = MagicMock()
-    first_result.collect.return_value = [[42]]
     ctx.spark.sql.side_effect = [
-        first_result,
         Exception(
         "[CAST_INVALID_INPUT] The value '' of the type \"STRING\" cannot be cast"
         " to \"BIGINT\" because it is malformed. Correct the value as per the"
@@ -418,11 +414,7 @@ def test_agg_query_dq_detailed_result_not_ansi_sql_query_post(_fixture_agg_dq_ru
     ctx.get_query_dq_rule_type_name = "query_dq"
     ctx.get_query_dq_detailed_stats_status = True
 
-
-    first_result = MagicMock()
-    first_result.collect.return_value = [[42]]
     ctx.spark.sql.side_effect = [
-        first_result,
         Exception("Some other error message not having to do with ANSI casting."),
     ]
 

--- a/tests/unit/utils/test_actions.py
+++ b/tests/unit/utils/test_actions.py
@@ -186,6 +186,25 @@ def test_agg_query_dq_detailed_result_ansi_expection_comparison(_fixture_agg_dq_
 
     with pytest.raises(SparkExpectationsMiscException):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+    
+def test_agg_query_dq_detailed_result_not_ansi_expection_comparison(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   _dq_rule["rule_type"] == _context.get_agg_dq_rule_type_name
+    #   _context.get_agg_dq_detailed_stats_status is True
+    #   if not (">" in _dq_rule["expectation"] and "<" in _dq_rule["expectation"])
+    #   if re.match(_re_compile, _dq_rule["expectation"])
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.get_agg_dq_rule_type_name = "agg_dq"
+    ctx.get_agg_dq_detailed_stats_status = True
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
+    mock_agg_result.collect.side_effect = Exception("Some other error message not having to do with ANSI casting.")
+
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
 
 def test_agg_query_dq_detailed_result_ansi_expection_range(_fixture_agg_dq_rule):
     # testing the following conditions in agg_query_dq_detailed_result:
@@ -208,6 +227,27 @@ def test_agg_query_dq_detailed_result_ansi_expection_range(_fixture_agg_dq_rule)
         " to \"BIGINT\" because it is malformed. Correct the value as per the"
         " syntax, or change its target type. Use `try_cast` to tolerate malformed"
         " input and return NULL instead.")
+
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+    
+def test_agg_query_dq_detailed_result_not_ansi_expection_range(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   _dq_rule["rule_type"] == _context.get_agg_dq_rule_type_name #("agg_dq")
+    #   _context.get_agg_dq_detailed_stats_status is True
+    #   if (">" in _dq_rule["expectation"] and "<" in _dq_rule["expectation"])
+    #   if re.match(_re_compile, _dq_rule["expectation"])
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.get_agg_dq_rule_type_name = "agg_dq"
+    ctx.get_agg_dq_detailed_stats_status = True
+
+    _fixture_agg_dq_rule["expectation"] = "sum(col1)>0 and sum(col1)<10"
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
+    mock_agg_result.collect.side_effect = Exception("Some other error message not having to do with ANSI casting.")
 
     with pytest.raises(SparkExpectationsMiscException):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])

--- a/tests/unit/utils/test_actions.py
+++ b/tests/unit/utils/test_actions.py
@@ -164,13 +164,7 @@ def test_multi_decorator_default_updates():
     assert ctx.get_error_table_name_user_specified is False
 
 
-def test_agg_query_dq_detailed_result_ansi_expection_comparison(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   _dq_rule["rule_type"] == _context.get_agg_dq_rule_type_name
-    #   _context.get_agg_dq_detailed_stats_status is True
-    #   if not (">" in _dq_rule["expectation"] and "<" in _dq_rule["expectation"])
-    #   if re.match(_re_compile, _dq_rule["expectation"])
-
+def test_agg_query_dq_detailed_result_agg_dq_comparison_ansi_exception(_fixture_agg_dq_rule):
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.get_agg_dq_rule_type_name = "agg_dq"
     ctx.get_agg_dq_detailed_stats_status = True
@@ -186,14 +180,9 @@ def test_agg_query_dq_detailed_result_ansi_expection_comparison(_fixture_agg_dq_
 
     with pytest.raises(SparkExpectationsMiscException):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
-    
-def test_agg_query_dq_detailed_result_not_ansi_expection_comparison(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   _dq_rule["rule_type"] == _context.get_agg_dq_rule_type_name
-    #   _context.get_agg_dq_detailed_stats_status is True
-    #   if not (">" in _dq_rule["expectation"] and "<" in _dq_rule["expectation"])
-    #   if re.match(_re_compile, _dq_rule["expectation"])
 
+
+def test_agg_query_dq_detailed_result_agg_dq_comparison_generic_exception(_fixture_agg_dq_rule):
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.get_agg_dq_rule_type_name = "agg_dq"
     ctx.get_agg_dq_detailed_stats_status = True
@@ -206,13 +195,8 @@ def test_agg_query_dq_detailed_result_not_ansi_expection_comparison(_fixture_agg
     with pytest.raises(SparkExpectationsMiscException):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
 
-def test_agg_query_dq_detailed_result_ansi_expection_range(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   _dq_rule["rule_type"] == _context.get_agg_dq_rule_type_name #("agg_dq")
-    #   _context.get_agg_dq_detailed_stats_status is True
-    #   if (">" in _dq_rule["expectation"] and "<" in _dq_rule["expectation"])
-    #   if re.match(_re_compile, _dq_rule["expectation"])
 
+def test_agg_query_dq_detailed_result_agg_dq_range_ansi_exception(_fixture_agg_dq_rule):
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.get_agg_dq_rule_type_name = "agg_dq"
     ctx.get_agg_dq_detailed_stats_status = True
@@ -230,14 +214,9 @@ def test_agg_query_dq_detailed_result_ansi_expection_range(_fixture_agg_dq_rule)
 
     with pytest.raises(SparkExpectationsMiscException):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
-    
-def test_agg_query_dq_detailed_result_not_ansi_expection_range(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   _dq_rule["rule_type"] == _context.get_agg_dq_rule_type_name #("agg_dq")
-    #   _context.get_agg_dq_detailed_stats_status is True
-    #   if (">" in _dq_rule["expectation"] and "<" in _dq_rule["expectation"])
-    #   if re.match(_re_compile, _dq_rule["expectation"])
 
+
+def test_agg_query_dq_detailed_result_agg_dq_range_generic_exception(_fixture_agg_dq_rule):
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.get_agg_dq_rule_type_name = "agg_dq"
     ctx.get_agg_dq_detailed_stats_status = True
@@ -252,13 +231,8 @@ def test_agg_query_dq_detailed_result_not_ansi_expection_range(_fixture_agg_dq_r
     with pytest.raises(SparkExpectationsMiscException):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
 
-def test_agg_query_dq_detailed_result_ansi_custom_query(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   _dq_rule["rule_type"] == _context.get_query_dq_rule_type_name #("query_dq")
-    #   _context.get_agg_dq_detailed_stats_status is True
-    #   if (_dq_rule["enable_querydq_custom_output"])
-    #   sub_key_value := _querydq_secondary_query.get(_dq_rule["product_id"] + "|" + _dq_rule["table_name"] + "|" + _dq_rule["rule"], {},)
 
+def test_agg_query_dq_detailed_result_query_dq_custom_sql_ansi_exception(_fixture_agg_dq_rule):
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
     ctx.get_query_dq_rule_type_name = "query_dq"
@@ -284,13 +258,7 @@ def test_agg_query_dq_detailed_result_ansi_custom_query(_fixture_agg_dq_rule):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
 
 
-def test_agg_query_dq_detailed_result_not_ansi_custom_query(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   _dq_rule["rule_type"] == _context.get_query_dq_rule_type_name #("query_dq")
-    #   _context.get_agg_dq_detailed_stats_status is True
-    #   if (_dq_rule["enable_querydq_custom_output"])
-    #   sub_key_value := _querydq_secondary_query.get(_dq_rule["product_id"] + "|" + _dq_rule["table_name"] + "|" + _dq_rule["rule"], {},)
-
+def test_agg_query_dq_detailed_result_query_dq_custom_sql_generic_exception(_fixture_agg_dq_rule):
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
     ctx.get_query_dq_rule_type_name = "query_dq"
@@ -312,11 +280,7 @@ def test_agg_query_dq_detailed_result_not_ansi_custom_query(_fixture_agg_dq_rule
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
 
 
-def test_agg_query_dq_detailed_result_ansi_sql_query(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
-    #   expectation must match pattern = rf"({left_expr})\s*({operator})\s*({right_value}|({right_expr}))|({left_expr})"
-
+def test_agg_query_dq_detailed_result_query_dq_sql_query_ansi_exception(_fixture_agg_dq_rule):
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
     ctx.get_query_dq_rule_type_name = "query_dq"
@@ -340,11 +304,7 @@ def test_agg_query_dq_detailed_result_ansi_sql_query(_fixture_agg_dq_rule):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
 
 
-def test_agg_query_dq_detailed_result_not_ansi_sql_query(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
-    #   expectation must match pattern = rf"({left_expr})\s*({operator})\s*({right_value}|({right_expr}))|({left_expr})"
-
+def test_agg_query_dq_detailed_result_query_dq_sql_query_generic_exception(_fixture_agg_dq_rule):
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
     ctx.get_query_dq_rule_type_name = "query_dq"
@@ -363,13 +323,8 @@ def test_agg_query_dq_detailed_result_not_ansi_sql_query(_fixture_agg_dq_rule):
     with pytest.raises(SparkExpectationsMiscException):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
 
-###########
-def test_agg_query_dq_detailed_result_ansi_sql_compare(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
-    #   expectation must match pattern = rf"({left_expr})\s*({operator})\s*({right_value}|({right_expr}))|({left_expr})"
 
-
+def test_agg_query_dq_detailed_result_query_dq_sql_compare_ansi_exception(_fixture_agg_dq_rule):
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
     ctx.get_query_dq_rule_type_name = "query_dq"
@@ -393,12 +348,7 @@ def test_agg_query_dq_detailed_result_ansi_sql_compare(_fixture_agg_dq_rule):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
 
 
-def test_agg_query_dq_detailed_result_not_ansi_sql_compare(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
-    #   expectation must match pattern = rf"({left_expr})\s*({operator})\s*({right_value}|({right_expr}))|({left_expr})"
-
-
+def test_agg_query_dq_detailed_result_query_dq_sql_compare_generic_exception(_fixture_agg_dq_rule):
     ctx = Mock(spec=SparkExpectationsContext)
     ctx.spark = Mock()
     ctx.get_query_dq_rule_type_name = "query_dq"
@@ -416,60 +366,4 @@ def test_agg_query_dq_detailed_result_not_ansi_sql_compare(_fixture_agg_dq_rule)
 
     with pytest.raises(SparkExpectationsMiscException):
         SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
-#############
 
-
-def test_agg_query_dq_detailed_result_ansi_sql_query_post(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
-
-
-    ctx = Mock(spec=SparkExpectationsContext)
-    ctx.spark = Mock()
-    ctx.get_query_dq_rule_type_name = "query_dq"
-    ctx.get_query_dq_detailed_stats_status = True
-
-    ctx.spark.sql.side_effect = [
-        Exception(
-        "[CAST_INVALID_INPUT] The value '' of the type \"STRING\" cannot be cast"
-        " to \"BIGINT\" because it is malformed. Correct the value as per the"
-        " syntax, or change its target type. Use `try_cast` to tolerate malformed"
-        " input and return NULL instead."),
-    ]
-
-    _fixture_agg_dq_rule["rule_type"] = "query_dq"
-    _fixture_agg_dq_rule["expectation"] = "(\"SELECT COUNT(*) FROM order_source WHERE order_date IS NULL\")"
-    _fixture_agg_dq_rule["enable_querydq_custom_output"] = False
-
-    mock_df = MagicMock()
-    mock_agg_result = MagicMock()
-    mock_df.agg.return_value = mock_agg_result
-
-    with pytest.raises(SparkExpectationsMiscException):
-        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
-
-
-def test_agg_query_dq_detailed_result_not_ansi_sql_query_post(_fixture_agg_dq_rule):
-    # testing the following conditions in agg_query_dq_detailed_result:
-    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
-
-
-    ctx = Mock(spec=SparkExpectationsContext)
-    ctx.spark = Mock()
-    ctx.get_query_dq_rule_type_name = "query_dq"
-    ctx.get_query_dq_detailed_stats_status = True
-
-    ctx.spark.sql.side_effect = [
-        Exception("Some other error message not having to do with ANSI casting."),
-    ]
-
-    _fixture_agg_dq_rule["rule_type"] = "query_dq"
-    _fixture_agg_dq_rule["expectation"] = "(\"SELECT COUNT(*) FROM order_source WHERE order_date IS NULL\")"
-    _fixture_agg_dq_rule["enable_querydq_custom_output"] = False
-
-    mock_df = MagicMock()
-    mock_agg_result = MagicMock()
-    mock_df.agg.return_value = mock_agg_result
-
-    with pytest.raises(SparkExpectationsMiscException):
-        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])

--- a/tests/unit/utils/test_actions.py
+++ b/tests/unit/utils/test_actions.py
@@ -162,3 +162,150 @@ def test_multi_decorator_default_updates():
     reader.get_rules_from_df(rules_df=_mock_rules_df_empty(), target_table="db.table_b")
     assert ctx.get_error_table_name == "db.table_b_error"  # Not "db.table_a_error"
     assert ctx.get_error_table_name_user_specified is False
+
+
+def test_agg_query_dq_detailed_result_ansi_expection_comparison(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   _dq_rule["rule_type"] == _context.get_agg_dq_rule_type_name
+    #   _context.get_agg_dq_detailed_stats_status is True
+    #   if not (">" in _dq_rule["expectation"] and "<" in _dq_rule["expectation"])
+    #   if re.match(_re_compile, _dq_rule["expectation"])
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.get_agg_dq_rule_type_name = "agg_dq"
+    ctx.get_agg_dq_detailed_stats_status = True
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
+    mock_agg_result.collect.side_effect = Exception(
+        "[CAST_INVALID_INPUT] The value '' of the type \"STRING\" cannot be cast"
+        " to \"BIGINT\" because it is malformed. Correct the value as per the"
+        " syntax, or change its target type. Use `try_cast` to tolerate malformed"
+        " input and return NULL instead.")
+
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+
+def test_agg_query_dq_detailed_result_ansi_expection_range(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   _dq_rule["rule_type"] == _context.get_agg_dq_rule_type_name #("agg_dq")
+    #   _context.get_agg_dq_detailed_stats_status is True
+    #   if (">" in _dq_rule["expectation"] and "<" in _dq_rule["expectation"])
+    #   if re.match(_re_compile, _dq_rule["expectation"])
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.get_agg_dq_rule_type_name = "agg_dq"
+    ctx.get_agg_dq_detailed_stats_status = True
+
+    _fixture_agg_dq_rule["expectation"] = "sum(col1)>0 and sum(col1)<10"
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
+    mock_agg_result.collect.side_effect = Exception(
+        "[CAST_INVALID_INPUT] The value '' of the type \"STRING\" cannot be cast"
+        " to \"BIGINT\" because it is malformed. Correct the value as per the"
+        " syntax, or change its target type. Use `try_cast` to tolerate malformed"
+        " input and return NULL instead.")
+
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+
+def test_agg_query_dq_detailed_result_ansi_custom_query(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   _dq_rule["rule_type"] == _context.get_query_dq_rule_type_name #("query_dq")
+    #   _context.get_agg_dq_detailed_stats_status is True
+    #   if (_dq_rule["enable_querydq_custom_output"])
+    #   sub_key_value := _querydq_secondary_query.get(_dq_rule["product_id"] + "|" + _dq_rule["table_name"] + "|" + _dq_rule["rule"], {},)
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.spark = Mock()
+    ctx.get_agg_dq_rule_type_name = "query_dq"
+    ctx.get_agg_dq_detailed_stats_status = True
+    ctx.get_querydq_secondary_queries = {
+        "product_1|test_table|col1_sum_gt_eq_6": {"source_f1": "some_query"}
+    }
+    ctx.spark.sql.side_effect = Exception(
+        "[CAST_INVALID_INPUT] The value '' of the type \"STRING\" cannot be cast"
+        " to \"BIGINT\" because it is malformed. Correct the value as per the"
+        " syntax, or change its target type. Use `try_cast` to tolerate malformed"
+        " input and return NULL instead.")
+
+    _fixture_agg_dq_rule["rule_type"] = "query_dq"
+    _fixture_agg_dq_rule["enable_querydq_custom_output"] = True
+    _fixture_agg_dq_rule["expectation_source_f1"] = "SELECT * FROM table"
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
+
+
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+
+def test_agg_query_dq_detailed_result_ansi_sql_query(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
+    #   expectation must match pattern = rf"({left_expr})\s*({operator})\s*({right_value}|({right_expr}))|({left_expr})"
+
+    actions = Mock(spec=SparkExpectationsActions)
+    actions.match_parentheses = True
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.spark = Mock()
+    ctx.get_agg_dq_rule_type_name = "query_dq"
+    ctx.get_agg_dq_detailed_stats_status = True
+
+    ctx.spark.sql.side_effect = Exception(
+        "[CAST_INVALID_INPUT] The value '' of the type \"STRING\" cannot be cast"
+        " to \"BIGINT\" because it is malformed. Correct the value as per the"
+        " syntax, or change its target type. Use `try_cast` to tolerate malformed"
+        " input and return NULL instead.")
+
+    _fixture_agg_dq_rule["rule_type"] = "query_dq"
+    _fixture_agg_dq_rule["expectation"] = "(\"SELECT COUNT(*) FROM order_source WHERE order_date IS NULL\")"
+    _fixture_agg_dq_rule["enable_querydq_custom_output"] = False
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
+
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])
+
+
+def test_agg_query_dq_detailed_result_ansi_sql_query_post(_fixture_agg_dq_rule):
+    # testing the following conditions in agg_query_dq_detailed_result:
+    #   SparkExpectationsActions.match_parentheses(_dq_rule["expectation"])
+
+    actions = Mock(spec=SparkExpectationsActions)
+    actions.match_parentheses = True
+
+    ctx = Mock(spec=SparkExpectationsContext)
+    ctx.spark = Mock()
+    ctx.get_agg_dq_rule_type_name = "query_dq"
+    ctx.get_agg_dq_detailed_stats_status = True
+
+
+    first_result = MagicMock()
+    first_result.collect.return_value = [[42]]
+    ctx.spark.sql.side_effect = [
+        first_result,
+        Exception(
+        "[CAST_INVALID_INPUT] The value '' of the type \"STRING\" cannot be cast"
+        " to \"BIGINT\" because it is malformed. Correct the value as per the"
+        " syntax, or change its target type. Use `try_cast` to tolerate malformed"
+        " input and return NULL instead."),
+    ]
+
+    _fixture_agg_dq_rule["rule_type"] = "query_dq"
+    _fixture_agg_dq_rule["expectation"] = "(\"SELECT COUNT(*) FROM order_source WHERE order_date IS NULL\")"
+    _fixture_agg_dq_rule["enable_querydq_custom_output"] = False
+
+    mock_df = MagicMock()
+    mock_agg_result = MagicMock()
+    mock_df.agg.return_value = mock_agg_result
+
+    with pytest.raises(SparkExpectationsMiscException):
+        SparkExpectationsActions().agg_query_dq_detailed_result(ctx, _fixture_agg_dq_rule, mock_df, [])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When using Databricks serverless compute, ANSI mode is on by default, which enforces stricter standards on some SQL commands, one of which is stricter casting behavior. 

This PR
- updates Spark Expectations internal code to use a cast function that is safe for ANSI mode usage
- updates documentation to guide the user to provide ANSI-compliant expectations if they use serverless
- updates error messages to be more informative when these errors are encountered

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/spark-expectations/issues/304

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See above. Enables casting in Spark Expectations to be ANSI-compliant.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new unit tests & ran

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
