### PR TITLE
fix: prevent silent overwrite of user 'action_if_failed' column

### DIFF
--- a/spark_expectations/utils/actions.py
+++ b/spark_expectations/utils/actions.py
@@ -26,6 +26,9 @@ from spark_expectations.core.exceptions import (
 from spark_expectations.utils.udf import get_actions_list, remove_empty_maps
 
 
+_INTERNAL_ACTION_IF_FAILED_COL = "__se_action_if_failed__"
+
+
 class SparkExpectationsActions:
     """
     This class implements/supports applying data quality rules on given dataframe and performing required action
@@ -672,10 +675,11 @@ class SparkExpectationsActions:
                 for dq_column in _df_dq.columns
                 if (dq_column.startswith(f"meta_{_rule_type}_results")) is False
             ]
-            _df_dq_columns.append("action_if_failed")
-            _df_dq = _df_dq.withColumn("action_if_failed", get_actions_list(col(f"meta_{_rule_type}_results"))).select(
-                _df_dq_columns
-            )
+            _df_dq_columns.append(_INTERNAL_ACTION_IF_FAILED_COL)
+            _df_dq = _df_dq.withColumn(
+                _INTERNAL_ACTION_IF_FAILED_COL,
+                get_actions_list(col(f"meta_{_rule_type}_results")),
+            ).select(_df_dq_columns)
 
             # Handle streaming DataFrames safely - cannot use .count() on streaming DataFrames
             if _df_dq.isStreaming:
@@ -686,11 +690,11 @@ class SparkExpectationsActions:
                 )
                 # For streaming, just filter out "drop" actions
                 # Note: "fail" actions cannot be enforced in streaming mode without counting
-                _df_dq = _df_dq.filter(~array_contains(_df_dq.action_if_failed, "drop"))
+                _df_dq = _df_dq.filter(~array_contains(col(_INTERNAL_ACTION_IF_FAILED_COL), "drop"))
             else:
                 # Batch DataFrame - can use .count() safely
-                if not _df_dq.filter(array_contains(_df_dq.action_if_failed, "fail")).count() > 0:
-                    _df_dq = _df_dq.filter(~array_contains(_df_dq.action_if_failed, "drop"))
+                if not _df_dq.filter(array_contains(col(_INTERNAL_ACTION_IF_FAILED_COL), "fail")).count() > 0:
+                    _df_dq = _df_dq.filter(~array_contains(col(_INTERNAL_ACTION_IF_FAILED_COL), "drop"))
                 else:
                     if _row_dq_flag:
                         _context.set_row_dq_status("Failed")

--- a/tests/integration/utils/test_actions.py
+++ b/tests/integration/utils/test_actions.py
@@ -1954,6 +1954,49 @@ def test_action_on_rules_streaming_skip(_fixture_mock_context):
     assert result_df.isStreaming is True
 
 
+def test_action_on_rules_preserves_user_action_if_failed_column(_fixture_mock_context):
+    """
+    Regression test: a user-supplied column literally named ``action_if_failed``
+    must survive ``action_on_rules`` unchanged. Before the internal transient
+    column was renamed to ``__se_action_if_failed__``, this column was silently
+    overwritten by ``get_actions_list(...)`` and the user lost their data.
+    """
+    # User DF carries an ``action_if_failed`` column whose values look like
+    # business strings (intentionally NOT overlapping with SE's "fail" / "drop"
+    # / "ignore" verbs) so we can prove the original values come back intact.
+    user_values = ["promote", "rollback", "hold"]
+    input_df = spark.createDataFrame(
+        [
+            {"row_id": 0, "col1": 1, "action_if_failed": user_values[0]},
+            {"row_id": 1, "col1": 2, "action_if_failed": user_values[1]},
+            {"row_id": 2, "col1": 3, "action_if_failed": user_values[2]},
+        ]
+    ).withColumn(
+        # All rules pass, so get_actions_list returns ["ignore"] -- no rows are
+        # dropped, and the user's column must be returned untouched on every row.
+        "meta_row_dq_results",
+        array(create_map(lit("status"), lit("pass"), lit("action_if_failed"), lit("ignore"))),
+    )
+
+    result_df = SparkExpectationsActions.action_on_rules(
+        _fixture_mock_context, input_df, 3, 0, 3, "row_dq", True
+    )
+
+    # Schema: original ``action_if_failed`` is preserved as a string column;
+    # no internal sentinel column should leak through.
+    result_fields = {f.name: f.dataType.simpleString() for f in result_df.schema.fields}
+    assert "action_if_failed" in result_fields
+    assert result_fields["action_if_failed"] == "string", (
+        f"User's action_if_failed column should still be string, got "
+        f"{result_fields['action_if_failed']}"
+    )
+    assert "__se_action_if_failed__" not in result_fields
+
+    # Values: original user values survive in row order.
+    returned = {row["row_id"]: row["action_if_failed"] for row in result_df.collect()}
+    assert returned == {0: "promote", 1: "rollback", 2: "hold"}
+
+
 def test_agg_query_dq_detailed_result_type_error_line_210(_fixture_agg_dq_rule, _fixture_mock_context):
     """Test line 210: TypeError for unexpected aggregation result type"""
     df = spark.createDataFrame([{"col1": 1}])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Spark Expectation doesn't mention reserved keywords/column names.  `action_if_failed` is one of those that silently overwrites a user column with the same name 

There are other reserved keywords `meta_dq_<>` but they have unique enough prefix that risk of collision is lower.

## Motivation and Context
action_on_rules appended a transient 'action_if_failed' column to the source DataFrame, clobbering any user column with the same name. 

Rename the internal column to a private sentinel '__se_action_if_failed__' so user columns are preserved. Pure refactor: the column is sliced off before return, output schema is unchanged.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
