### PR TITLE
set action_if_failed default to ignore

### DIFF
--- a/spark_expectations/utils/reader.py
+++ b/spark_expectations/utils/reader.py
@@ -334,7 +334,7 @@ class SparkExpectationsReader:
                         "rule": row["rule"].format(**params),
                         "column_name": row["column_name"],
                         "expectation": row["expectation"],
-                        "action_if_failed": row["action_if_failed"],
+                        "action_if_failed": row["action_if_failed"] if row["action_if_failed"] else "ignore",
                         "enable_for_source_dq_validation": row["enable_for_source_dq_validation"],
                         "enable_for_target_dq_validation": row["enable_for_target_dq_validation"],
                         "tag": row["tag"],

--- a/tests/integration/utils/test_reader.py
+++ b/tests/integration/utils/test_reader.py
@@ -688,6 +688,71 @@ def test_get_rules_from_table(
     assert expectations == expected_expectations
     assert rule_execution_settings == expected_rule_execution_settings
 
+@pytest.mark.parametrize(
+    "action_input, expected_action",
+    [
+        (None, "ignore"),
+        ("", "ignore"),
+        ("drop", "drop"),
+        ("fail", "fail"),
+        ("ignore", "ignore"),
+    ]
+)
+def test_action_if_failed_defaults_to_ignore(action_input, expected_action):
+
+    # Create an instance of the class and set the product_id
+    mock_context = Mock(spec=SparkExpectationsContext)
+    setattr(mock_context, "get_row_dq_rule_type_name", "row_dq")
+    setattr(mock_context, "get_agg_dq_rule_type_name", "agg_dq")
+    setattr(mock_context, "get_query_dq_rule_type_name", "query_dq")
+    mock_context.spark = spark
+    mock_context.product_id = "product1"
+
+    reader_handler = SparkExpectationsReader(mock_context)
+
+    rules_schema = StructType(
+        [
+            StructField("product_id", StringType()),
+            StructField("table_name", StringType()),
+            StructField("rule_type", StringType()),
+            StructField("rule", StringType()),
+            StructField("column_name", StringType()),
+            StructField("expectation", StringType()),
+            StructField("action_if_failed", StringType()),
+            StructField("tag", StringType()),
+            StructField("description", StringType()),
+            StructField("enable_for_source_dq_validation", BooleanType()),
+            StructField("enable_for_target_dq_validation", BooleanType()),
+            StructField("is_active", BooleanType()),
+            StructField("enable_error_drop_alert", BooleanType()),
+            StructField("error_drop_threshold", IntegerType())
+        ]
+    )
+
+    rules_row = (
+        "product1",                 # product_id
+        "table1",                   # table_name
+        "row_dq",                   # rule_type
+        "rule_name",                # rule
+        "column1",                  # column_name
+        "column1 IS NOT NULL",      # expectation
+        action_input,               # action_if_failed
+        "completeness",             # tag
+        "test rule",                # description
+        True,                       # enable_for_source_dq_validation
+        True,                       # enable_for_target_dq_validation
+        True,                       # is_active
+        False,                         # enable_error_drop_alert
+        0,                         # error_drop_threshold
+    )
+
+    test_rules_df = spark.createDataFrame([rules_row], schema=rules_schema)
+
+    dq_queries_dict, expectations, rule_execution_settings = reader_handler.get_rules_from_df(test_rules_df, target_table="table1", is_dlt=False)
+
+    row_dq_rules = expectations["row_dq_rules"]
+    assert len(row_dq_rules) == 1
+    assert row_dq_rules[0]["action_if_failed"] == expected_action
 
 def test_set_notification_param_exception(_fixture_reader):
     with pytest.raises(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently in Spark Expectations if the rules are read from a table or given as a DataFrame, `action_if_failed` is allowed to be None. This closes that loophole and sets it to "ignore" by default.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/spark-expectations/issues/319

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
More complete and tighter Spark Expectations results (and therefore data quality records). Having "none" as the action if a rule fails is the same as setting the action if a rule fails to be "ignore it".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in integration tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
